### PR TITLE
Refactor: simplify container

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -388,6 +388,10 @@ def draw_avalon_menu(self, context):
     self.layout.menu(TOPBAR_MT_avalon.bl_idname)
 
 
+class OpenpypeInstance(bpy.types.PropertyGroup):
+    collection_name: bpy.props.StringProperty(name="Collection name used as instance")
+
+
 classes = [
     LaunchCreator,
     LaunchLoader,
@@ -396,6 +400,7 @@ classes = [
     LaunchLibrary,
     LaunchWorkFiles,
     TOPBAR_MT_avalon,
+    OpenpypeInstance,
 ]
 
 
@@ -411,6 +416,9 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.TOPBAR_MT_editor_menus.append(draw_avalon_menu)
 
+    # Properties
+    bpy.types.Scene.openpype_instances = bpy.props.CollectionProperty(type=OpenpypeInstance)
+
 
 def unregister():
     """Unregister the operators and menu."""
@@ -420,3 +428,5 @@ def unregister():
     bpy.types.TOPBAR_MT_editor_menus.remove(draw_avalon_menu)
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
+
+    del bpy.types.Scene.openpype_instances

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -381,8 +381,18 @@ def ls() -> Iterator:
 
     collections = lib.lsattr("id", AVALON_CONTAINER_ID)
     scene_collections = bpy.context.scene.collection.children_recursive
+
+    # Get all instanced collections
+    instanced_collections = {
+        obj.instance_collection
+        for obj in bpy.context.scene.objects
+        if obj.is_instancer
+    }
+    
     for container in collections:
-        if container in scene_collections and not container.override_library:
+        if (
+            container in scene_collections and not container.override_library
+        ) or container in instanced_collections:
             yield parse_container(container)
 
 

--- a/openpype/hosts/blender/plugins/load/load_model.py
+++ b/openpype/hosts/blender/plugins/load/load_model.py
@@ -24,17 +24,19 @@ class BlendModelLoader(plugin.AssetLoader):
     color = "orange"
     color_tag = "COLOR_04"
 
-    def _process(self, libpath, asset_group):
+    def _process(self, libpath, asset_group, override_lib=True):
 
         # If asset_group is a Collection, we proceed with usual load blend.
         if isinstance(asset_group, bpy.types.Collection):
-            self._load_blend(libpath, asset_group)
+            asset_group = self._load_blend(libpath, asset_group, override_lib)
 
         # If asset_group is an Empty, set instance collection with container.
         elif isinstance(asset_group, bpy.types.Object):
             container = self._load_library_collection(libpath)
             asset_group.instance_collection = container
             asset_group.instance_type = 'COLLECTION'
+
+        return asset_group
 
     @staticmethod
     def _apply_options(asset_group, options):

--- a/openpype/hosts/blender/plugins/publish/collect_instances.py
+++ b/openpype/hosts/blender/plugins/publish/collect_instances.py
@@ -16,16 +16,17 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
     @staticmethod
     def get_collections() -> Generator:
-        """Return all 'model' collections.
+        """Return all collections marked as OpenPype "instance".
 
-        Check if the family is 'model' and if it doesn't have the
-        representation set. If the representation is set, it is a loaded model
-        and we don't want to publish it.
+        The property `bpy.context.scene.openpype_instances` keeps
+        track of the collections created as OP instances for the current scene.
         """
-        for collection in bpy.context.scene.collection.children:
-            avalon_prop = collection.get(AVALON_PROPERTY) or dict()
-            if avalon_prop.get('id') == 'pyblish.avalon.instance':
-                yield collection
+        instance_collections = {
+            bpy.data.collections.get(instance.collection_name)
+            for instance in bpy.context.scene.openpype_instances
+        }
+        for collection in instance_collections:
+            yield collection
 
     def process(self, context):
         """Collect the models from the current Blender scene."""

--- a/openpype/plugins/publish/integrate_new.py
+++ b/openpype/plugins/publish/integrate_new.py
@@ -590,18 +590,27 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     continue
                 repre_context[key] = template_data[key]
 
+            # Initialize ID, trying to get it from an earlier stage
+            repre_id = repre.get('id')
+
+            # If ID has been created in early stage, cast to ObjectId from str
+            if repre_id:
+                repre_id = ObjectId(repre_id)
+
             # Use previous representation's id if there are any
-            repre_id = None
             repre_name_low = repre["name"].lower()
             for _repre in existing_repres:
                 # NOTE should we check lowered names?
                 if repre_name_low == _repre["name"]:
                     repre_id = _repre["orig_id"]
                     break
+            # NOTE the above loop could be simplified like this:
+            # repre_id = next((_repre["orig_id"] for _repre in existing_repres if repre_name_low == _repre["name"]), repre_id)
 
             # Create new id if existing representations does not match
             if repre_id is None:
                 repre_id = ObjectId()
+                # NOTE this could be set as default value for repre_id
 
             data = repre.get("data") or {}
             data.update({'path': dst, 'template': template})


### PR DESCRIPTION
Containerize at `extract` to allow Blender native link functions.

## TODO
- [x] Guess `namespace` and `objectName` to drop the metadata: cannot be done without a big refactor, left like it is.