### PR TITLE
Minor changes of ftrack delete versions

### DIFF
--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -4,7 +4,6 @@ import uuid
 
 import clique
 from pymongo import UpdateOne
-import importlib
 import qargparse
 from Qt import QtWidgets, QtCore
 
@@ -373,7 +372,8 @@ class DeleteOldVersions(load.SubsetLoaderPlugin):
 
         if get_system_settings()["modules"]["ftrack"]["enabled"]:
             # Set attribute `is_published` to `False` on ftrack AssetVersions
-            ftrack_api = importlib.import_module("ftrack_api")
+            import ftrack_api
+
             session = ftrack_api.Session()
             query = (
                 "AssetVersion where asset.parent.id is \"{}\""

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -417,7 +417,7 @@ class DeleteOldVersions(load.SubsetLoaderPlugin):
                 "select id, is_published from AssetVersion where"
                 " asset.parent.id is \"{}\""
                 " and asset.name is \"{}\""
-                " and version in (\"{}\")"
+                " and version in ({})"
             ).format(
                 asset_ftrack_id,
                 subset_name,

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -423,7 +423,7 @@ class DeleteOldVersions(load.SubsetLoaderPlugin):
                 subset_name,
                 ",".join(versions)
             )
-        )
+        ).all()
 
         # Set attribute `is_published` to `False` on ftrack AssetVersions
         for asset_version in asset_versions:

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -10,7 +10,7 @@ from Qt import QtWidgets, QtCore
 from openpype import style
 from openpype.pipeline import load, AvalonMongoDB, Anatomy
 from openpype.lib import StringTemplate
-from openpype.settings import get_system_settings
+from openpype.modules import ModulesManager
 
 
 class DeleteOldVersions(load.SubsetLoaderPlugin):
@@ -370,7 +370,9 @@ class DeleteOldVersions(load.SubsetLoaderPlugin):
 
         self.dbcon.uninstall()
 
-        if get_system_settings()["modules"]["ftrack"]["enabled"]:
+        modules_manager = ModulesManager()
+        ftrack_module = modules_manager.modules_by_name.get("ftrack")
+        if ftrack_module and ftrack_module.enabled:
             # Set attribute `is_published` to `False` on ftrack AssetVersions
             import ftrack_api
 

--- a/openpype/plugins/load/delete_old_versions.py
+++ b/openpype/plugins/load/delete_old_versions.py
@@ -370,44 +370,75 @@ class DeleteOldVersions(load.SubsetLoaderPlugin):
 
         self.dbcon.uninstall()
 
-        modules_manager = ModulesManager()
-        ftrack_module = modules_manager.modules_by_name.get("ftrack")
-        if ftrack_module and ftrack_module.enabled:
-            # Set attribute `is_published` to `False` on ftrack AssetVersions
-            import ftrack_api
-
-            session = ftrack_api.Session()
-            query = (
-                "AssetVersion where asset.parent.id is \"{}\""
-                " and asset.name is \"{}\""
-                " and version is \"{}\""
-            )
-            for v in data["versions"]:
-                try:
-                    ftrack_version = session.query(
-                        query.format(
-                            data["asset"]["data"]["ftrackId"],
-                            data["subset"]["name"],
-                            v["name"]
-                        )
-                    ).one()
-                except ftrack_api.exception.NoResultFoundError:
-                    continue
-
-                ftrack_version["is_published"] = False
-
-            try:
-                session.commit()
-
-            except Exception:
-                msg = (
-                    "Could not set `is_published` attribute to `False`"
-                    " for selected AssetVersions."
-                )
-                self.log.error(msg)
-                self.message(msg)
+        self._ftrack_delete_versions(data)
 
         return size
+
+    def _ftrack_delete_versions(self, data):
+        """Delete version on ftrack.
+
+        Handling of ftrack logic in this plugin is not ideal. But in OP3 it is
+        almost impossible to solve the issue other way.
+
+        Note:
+            Asset versions on ftrack are not deleted but marked as
+                "not published" which cause that they're invisible.
+
+        Args:
+            data (dict): Data sent to subset loader with full context.
+        """
+
+        # First check for ftrack id on asset document
+        #   - skip if ther is none
+        asset_ftrack_id = data["asset"]["data"].get("ftrackId")
+        if not asset_ftrack_id:
+            self.log.info((
+                "Asset does not have filled ftrack id. Skipped delete"
+                " of ftrack version."
+            ))
+            return
+
+        # Check if ftrack module is enabled
+        modules_manager = ModulesManager()
+        ftrack_module = modules_manager.modules_by_name.get("ftrack")
+        if not ftrack_module or not ftrack_module.enabled:
+            return
+
+        import ftrack_api
+
+        session = ftrack_api.Session()
+        subset_name = data["subset"]["name"]
+        versions = {
+            '"{}"'.format(version_doc["name"])
+            for version_doc in data["versions"]
+        }
+        asset_versions = session.query(
+            (
+                "select id, is_published from AssetVersion where"
+                " asset.parent.id is \"{}\""
+                " and asset.name is \"{}\""
+                " and version in (\"{}\")"
+            ).format(
+                asset_ftrack_id,
+                subset_name,
+                ",".join(versions)
+            )
+        )
+
+        # Set attribute `is_published` to `False` on ftrack AssetVersions
+        for asset_version in asset_versions:
+            asset_version["is_published"] = False
+
+        try:
+            session.commit()
+
+        except Exception:
+            msg = (
+                "Could not set `is_published` attribute to `False`"
+                " for selected AssetVersions."
+            )
+            self.log.error(msg)
+            self.message(msg)
 
     def load(self, contexts, name=None, namespace=None, options=None):
         try:


### PR DESCRIPTION
## Brief description
Good point. Just small changes related to handling ftrack.

## Changes
- Direct import of ftrack api instead of using importlib -> there is no reason to import using string instead of direct import
- Use ftrack module instead of system settings to determine if is enabled -> module settings are module specific and only the module should use it (if ftrack's settings would change this should not be affected) also enabled ftrack in settings does not mean it is enabled in code.
- Moved ftrack logic to separated method -> cleaner code of the plugin and easier handling of issues related to ftrack