### PR TITLE
Several 'look' family fixes

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/extract_thumbnail.py
@@ -19,7 +19,7 @@ class ExtractThumbnail(openpype.api.Extractor):
 
     label = "Extract Thumbnail"
     hosts = ["blender"]
-    families = ["review", "model", "rig"]
+    families = ["review", "model", "rig", "look"]
     order = pyblish.api.ExtractorOrder + 0.01
 
     def process(self, instance):

--- a/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
+++ b/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
@@ -9,7 +9,7 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     label = "Increment Workfile Version"
     optional = True
     hosts = ["blender"]
-    families = ["animation", "model", "rig", "action", "layout", "setdress"]
+    families = ["animation", "model", "rig", "action", "layout", "setdress", "look"]
 
     def process(self, context):
 

--- a/openpype/hosts/blender/plugins/publish/integrate_thumbnail.py
+++ b/openpype/hosts/blender/plugins/publish/integrate_thumbnail.py
@@ -7,4 +7,4 @@ class IntegrateThumbnails(integrate_thumbnail.IntegrateThumbnails):
 
     label = "Integrate Thumbnails"
     order = pyblish.api.IntegratorOrder + 0.01
-    families = ["review", "model", "rig"]
+    families = ["review", "model", "rig", "look"]

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -37,7 +37,6 @@
                 "model",
                 "camera",
                 "rig",
-                "look",
                 "action",
                 "layout",
                 "setdress"


### PR DESCRIPTION
## Brief description

- Remove `look` from default setting of ExtractBlend because uses ExtractBlendLook.
- Add workfile increment for `look` family.