### PR TITLE
Fix: error custom property deletion with del missing in written library

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend_look.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend_look.py
@@ -94,8 +94,8 @@ class ExtractBlendLook(openpype.api.Extractor):
         for image, sourcepath in remapped:
             image.filepath = sourcepath.as_posix()
 
-        del collection["materials_assignment"]
-        del collection["materials_indexes"]
+        collection.pop("materials_assignment")
+        collection.pop("materials_indexes")
 
         for material in materials:
             material.use_fake_user = False


### PR DESCRIPTION
## Brief description
Because del removes from the memory it may lead to missing reference. dict.pop() is safer because local.