### PR TITLE
Fix: Embedded linked libraries are not correctly remapped between remote and studio

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1000,7 +1000,7 @@ class AssetLoader(LoaderPlugin):
         for obj in get_container_objects(asset_group):
 
             if obj is not asset_group:
-                obj.name = f"{namespace}-{obj.name}"
+                obj.name = f"{namespace}:{obj.name}"
 
             if obj.data and not obj.data.library and obj.data.users == 1:
                 objects_data.add(obj.data)
@@ -1016,17 +1016,17 @@ class AssetLoader(LoaderPlugin):
                 if anim_data:
                     action = anim_data.action
                     if action and not action.library and action.users == 1:
-                        action.name = f"{namespace}-{anim_data.action.name}"
+                        action.name = f"{namespace}:{anim_data.action.name}"
 
         for data in objects_data:
-            data.name = f"{namespace}-{data.name}"
+            data.name = f"{namespace}:{data.name}"
 
         for material in materials:
-            material.name = f"{namespace}-{material.name}"
+            material.name = f"{namespace}:{material.name}"
 
         if isinstance(asset_group, bpy.types.Collection):
             for child in set(get_children_recursive(asset_group)):
-                child.name = f"{namespace}-{child.name}"
+                child.name = f"{namespace}:{child.name}"
 
     def _load_library_collection(
         self, libpath: str, link: Optional[bool] = True

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1000,7 +1000,7 @@ class AssetLoader(LoaderPlugin):
         for obj in get_container_objects(asset_group):
 
             if obj is not asset_group:
-                obj.name = f"{namespace}:{obj.name}"
+                obj.name = f"{namespace}-{obj.name}"
 
             if obj.data and not obj.data.library and obj.data.users == 1:
                 objects_data.add(obj.data)
@@ -1016,17 +1016,17 @@ class AssetLoader(LoaderPlugin):
                 if anim_data:
                     action = anim_data.action
                     if action and not action.library and action.users == 1:
-                        action.name = f"{namespace}:{anim_data.action.name}"
+                        action.name = f"{namespace}-{anim_data.action.name}"
 
         for data in objects_data:
-            data.name = f"{namespace}:{data.name}"
+            data.name = f"{namespace}-{data.name}"
 
         for material in materials:
-            material.name = f"{namespace}:{material.name}"
+            material.name = f"{namespace}-{material.name}"
 
         if isinstance(asset_group, bpy.types.Collection):
             for child in set(get_children_recursive(asset_group)):
-                child.name = f"{namespace}:{child.name}"
+                child.name = f"{namespace}-{child.name}"
 
     def _load_library_collection(
         self, libpath: str, link: Optional[bool] = True

--- a/openpype/hosts/blender/plugins/publish/integrate_blend.py
+++ b/openpype/hosts/blender/plugins/publish/integrate_blend.py
@@ -1,0 +1,43 @@
+from subprocess import Popen
+
+import bpy
+
+from openpype.hosts.blender.utility_scripts import make_paths_relative
+from openpype.plugins.publish.integrate import IntegrateAsset
+
+
+class IntegrateBlenderAsset(IntegrateAsset):
+    label = "Integrate Blender Asset"
+    hosts = ["blender"]
+
+    def process(self, instance):
+        representations = instance.data.get("published_representations")
+
+        for repre_id, representation in representations.items():
+            published_path = (
+                representation.get("representation", {})
+                .get("data", {})
+                .get("path")
+            )
+
+            # If not workfile, it is a blend and there is a published file
+            if (
+                representation.get("anatomy_data", {}).get("family")
+                != "workfile"
+                and representation.get("representation", {}).get("name")
+                == "blend"
+                and published_path
+            ):
+                self.log.info(
+                    f"Running {make_paths_relative.__file__} to {published_path}..."
+                )
+                # Run in subprocess
+                Popen(
+                    [
+                        bpy.app.binary_path,
+                        published_path,
+                        "-b",
+                        "-P",
+                        make_paths_relative.__file__,
+                    ]
+                )

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -1,0 +1,7 @@
+import bpy
+
+
+if __name__ == "__main__":
+    bpy.ops.file.make_paths_relative()
+
+    bpy.ops.wm.save_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -1,3 +1,5 @@
+"""Make all paths relative."""
+
 import bpy
 
 


### PR DESCRIPTION
## Brief description
Added an new integrate process `Integrate Blender Asset` to be performed after regular integration to run `make_paths_relative()` to published blend files in order to make remote and studio paths compatible.