### PR TITLE
Feature: Pre-Launch convert blend file paths to absolute before opening

### DIFF
--- a/openpype/hooks/pre_blend_add_make_paths_absolute_arg.py
+++ b/openpype/hooks/pre_blend_add_make_paths_absolute_arg.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from openpype.lib import PreLaunchHook
 from openpype.hosts.blender import utility_scripts
+from openpype.settings.lib import get_project_settings
 
 
 class AddMakePathsAbsoluteToLaunchArgs(PreLaunchHook):
@@ -16,10 +17,20 @@ class AddMakePathsAbsoluteToLaunchArgs(PreLaunchHook):
     ]
 
     def execute(self):
-        # TODO Setting
+        # Check enabled in settings
+        project_name = self.data["project_name"]
+        project_settings = get_project_settings(project_name)
+        host_name = self.application.host_name
+        host_settings = project_settings.get(host_name)
+        if not host_settings:
+            self.log.info('Host "{}" doesn\'t have settings'.format(host_name))
+            return None
+
+        if not host_settings.get("general", {}).get("use_paths_management"):
+            return
 
         self.log.info(
-            "Opening blend file with all paths converted to absolute."
+            "Opening blend file with all paths converted to absolute"
         )
         # Add path to workfile to arguments
         self.launch_context.launch_args.extend(

--- a/openpype/hooks/pre_blend_add_make_paths_absolute_arg.py
+++ b/openpype/hooks/pre_blend_add_make_paths_absolute_arg.py
@@ -1,0 +1,32 @@
+import os
+
+from pathlib import Path
+
+from openpype.lib import PreLaunchHook
+from openpype.hosts.blender import utility_scripts
+
+
+class AddMakePathsAbsoluteToLaunchArgs(PreLaunchHook):
+    """Run `file.make_paths_absolute` operator before open."""
+
+    # Append after file argument
+    order = 11
+    app_groups = [
+        "blender",
+    ]
+
+    def execute(self):
+        # TODO Setting
+
+        self.log.info(
+            "Opening blend file with all paths converted to absolute."
+        )
+        # Add path to workfile to arguments
+        self.launch_context.launch_args.extend(
+            [
+                "-P",
+                Path(utility_scripts.__file__).parent.joinpath(
+                    "make_paths_absolute.py"
+                ),
+            ]
+        )

--- a/openpype/hosts/blender/hooks/pre_add_make_paths_absolute_arg.py
+++ b/openpype/hosts/blender/hooks/pre_add_make_paths_absolute_arg.py
@@ -1,5 +1,3 @@
-import os
-
 from pathlib import Path
 
 from openpype.lib import PreLaunchHook
@@ -38,6 +36,6 @@ class AddMakePathsAbsoluteToLaunchArgs(PreLaunchHook):
                 "-P",
                 Path(utility_scripts.__file__).parent.joinpath(
                     "make_paths_absolute.py"
-                ),
+                ).as_posix(),
             ]
         )

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -1,4 +1,4 @@
-"""Make all paths relative."""
+"""Make all paths absolute."""
 
 import bpy
 
@@ -7,8 +7,8 @@ from openpype.lib.log import Logger
 if __name__ == "__main__":
     log = Logger().get_logger()
     log.debug(
-        f"Blend file | All paths converted to relative: {bpy.data.filepath}"
+        f"Blend file | All paths converted to absolute: {bpy.data.filepath}"
     )
 
-    bpy.ops.file.make_paths_relative()
+    bpy.ops.file.make_paths_absolute()
     bpy.ops.wm.save_mainfile()

--- a/openpype/settings/defaults/project_settings/blender.json
+++ b/openpype/settings/defaults/project_settings/blender.json
@@ -1,6 +1,7 @@
 {
     "general": {
-        "compress": false
+        "compress": false,
+        "use_paths_management": false
     },
     "workfile_builder": {
         "create_first_version": false,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -15,6 +15,11 @@
                     "type": "boolean",
                     "key": "compress",
                     "label": "Use file compress on save"
+                },
+                {
+                    "type": "boolean",
+                    "key": "use_paths_management",
+                    "label": "Manage paths: Published -> Relative | Workfile -> Absolute"
                 }
             ]
         },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_blender.json
@@ -19,7 +19,7 @@
                 {
                     "type": "boolean",
                     "key": "use_paths_management",
-                    "label": "Manage paths: Published -> Relative | Workfile -> Absolute"
+                    "label": "Paths background management"
                 }
             ]
         },

--- a/website/docs/admin_hosts_blender.md
+++ b/website/docs/admin_hosts_blender.md
@@ -85,6 +85,6 @@ You can close new terminal. Run pip install command above again. Now should work
 ## Settings
 ### General
 - Use file compress on save: All published files are compressed using Blender's native algorithm.
-- Paths background management: In order to make remote working easier using sites sync by keeping blend file's references during file copies, paths must be constantly converted between relative and absolute. The user must always work in absolute paths, and the published files must store paths as relative. This option ensures this convertion in background. In short:
+- Paths background management: In order to make remote working easier using sites sync by keeping blend file's references during file copies, paths must be constantly converted between relative and absolute. The user must always work in absolute paths, and the published files must store paths as relative. This option ensures this conversion in background. In short:
   - Published files: Relative paths
   - Workfiles: Absolute paths

--- a/website/docs/admin_hosts_blender.md
+++ b/website/docs/admin_hosts_blender.md
@@ -81,3 +81,10 @@ You can close new terminal. Run pip install command above again. Now should work
 </TabItem>
 
 </Tabs>
+
+## Settings
+### General
+- Use file compress on save: All published files are compressed using Blender's native algorithm.
+- Paths background management: In order to make remote working easier using sites sync by keeping blend file's references during file copies, paths must be constantly converted between relative and absolute. The user must always work in absolute paths, and the published files must store paths as relative. This option ensures this convertion in background. In short:
+  - Published files: Relative paths
+  - Workfiles: Absolute paths


### PR DESCRIPTION
## Brief description
In order to make remote working easier using sites sync by keeping blend file's references during file copies, paths must be constantly converted between relative and absolute. The user must always work in absolute paths, and the published files must store paths as relative. This option ensures this conversion in background. In short:
  - Published files: Relative paths
  - Workfiles: Absolute paths

Added a `PreLaunchHook` to run `make_paths_absolute` as script in command argument before the blend file is opened.