### PR TITLE
Fix: Make relative paths for UNC on Windows

### DIFF
--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -10,19 +10,18 @@ if __name__ == "__main__":
         f"Blend file | All paths converted to relative: {bpy.data.filepath}"
     )
     # Resolve path from source filepath with the relative filepath
-    datablocks_with_filepath = [
-        datablock
-        for datablock in list(bpy.data.libraries) + list(bpy.data.images)
-        if not datablock.is_library_indirect
-    ]
-    for datablock in datablocks_with_filepath:
+    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
-            if not datablock.filepath.startswith("//"):
+            if (
+                datablock
+                and not datablock.is_library_indirect
+                and datablock.filepath.startswith("//")
+            ):
                 datablock.filepath = bpy.path.relpath(
                     str(Path(datablock.filepath).resolve()),
                     start=str(Path(bpy.data.filepath).parent.resolve()),
                 )
-        except (RuntimeError, ValueError, OSError) as e:
+        except (RuntimeError, ReferenceError, ValueError, OSError) as e:
             log.error(e)
 
     bpy.ops.file.make_paths_relative()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
                     str(Path(datablock.filepath).resolve()),
                     start=str(Path(bpy.data.filepath).parent.resolve()),
                 )
-        except (RuntimeError, ValueError) as e:
+        except (RuntimeError, ValueError, OSError) as e:
             log.error(e)
 
     bpy.ops.file.make_paths_relative()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -1,5 +1,7 @@
 """Make all paths relative."""
 
+from pathlib import Path
+from itertools import chain
 import bpy
 
 from openpype.lib.log import Logger
@@ -10,7 +12,7 @@ if __name__ == "__main__":
         f"Blend file | All paths converted to relative: {bpy.data.filepath}"
     )
     # Resolve path from source filepath with the relative filepath
-    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
+    for datablock in chain(bpy.data.libraries, bpy.data.images):
         try:
             if (
                 datablock

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -9,6 +9,21 @@ if __name__ == "__main__":
     log.debug(
         f"Blend file | All paths converted to relative: {bpy.data.filepath}"
     )
+    # Resolve path from source filepath with the relative filepath
+    datablocks_with_filepath = [
+        datablock
+        for datablock in list(bpy.data.libraries) + list(bpy.data.images)
+        if not datablock.is_library_indirect
+    ]
+    for datablock in datablocks_with_filepath:
+        try:
+            if not datablock.filepath.startswith("//"):
+                datablock.filepath = bpy.path.relpath(
+                    str(Path(datablock.filepath).resolve()),
+                    start=str(Path(bpy.data.filepath).parent.resolve()),
+                )
+        except (RuntimeError, ValueError) as e:
+            log.error(e)
 
     bpy.ops.file.make_paths_relative()
     bpy.ops.wm.save_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
             if (
                 datablock
                 and not datablock.is_library_indirect
-                and datablock.filepath.startswith("//")
+                and not datablock.filepath.startswith("//")
             ):
                 datablock.filepath = bpy.path.relpath(
                     str(Path(datablock.filepath).resolve()),


### PR DESCRIPTION
## Brief description
On Windows, UNC paths are resolved by substituting the letter by the UNC code (Y: -> \\Srv_fab02\ww) which makes fail the `ops.make_paths_relative` which doesn't make the conversion. Resolving it with pathlib fixes this issue.