### PR TITLE
Fix: Gather into collection available when Collection is allowed

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -575,13 +575,8 @@ class SCENE_OT_CreateOpenpypeInstance(
                 row.prop(self, "datapath", text="", icon_only=True)
 
         # Checkbox to gather selected element in outliner
-        if {
-            t[0]
-            for t in context.scene["openpype_creators"][self.creator_name][
-                "bl_types"
-            ]
-        } <= {BL_TYPE_DATAPATH.get(t) for t in BL_OUTLINER_TYPES}:
-            layout.prop(self, "gather_into_collection")
+        draw_gather_into_collection(self, layout)
+
 
     def execute(self, _context):
         if not self.asset_name:
@@ -689,13 +684,7 @@ class SCENE_OT_AddToOpenpypeInstance(
             row.prop(self, "datapath", text="", icon_only=True)
 
         # Checkbox to gather selected element in outliner
-        if {
-            t[0]
-            for t in context.scene["openpype_creators"][self.creator_name][
-                "bl_types"
-            ]
-        } <= {BL_TYPE_DATAPATH.get(t) for t in BL_OUTLINER_TYPES}:
-            layout.prop(self, "gather_into_collection")
+        draw_gather_into_collection(self, context)
 
     def execute(self, context):
         # Get datablock
@@ -738,6 +727,21 @@ class SCENE_OT_AddToOpenpypeInstance(
         )
 
         return {"FINISHED"}
+
+
+
+def draw_gather_into_collection(self, context):
+    """Draw checkbox to gather selected element in outliner.
+    
+    Only if collections are handled by creator family.
+    """
+    if self.datapath in {BL_TYPE_DATAPATH.get(t) for t in BL_OUTLINER_TYPES} and bpy.types.Collection.__name__ in {
+        t[1]
+        for t in context.scene["openpype_creators"][self.creator_name][
+            "bl_types"
+        ]
+    }:
+        self.layout.prop(self, "gather_into_collection")
 
 
 class SCENE_OT_RemoveFromOpenpypeInstance(

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -575,7 +575,7 @@ class SCENE_OT_CreateOpenpypeInstance(
                 row.prop(self, "datapath", text="", icon_only=True)
 
         # Checkbox to gather selected element in outliner
-        draw_gather_into_collection(self, layout)
+        draw_gather_into_collection(self, context)
 
 
     def execute(self, _context):

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -555,9 +555,7 @@ class Creator(LegacyCreator):
         imprint(op_instance, self.data)
 
         # Process outliner if current creator relates to this types
-        if gather_into_collection and all(
-            t in self.bl_types for t in BL_OUTLINER_TYPES
-        ):
+        if gather_into_collection and bpy.types.Collection in self.bl_types:
             container_collection = self._process_outliner(datablocks, name)
             imprint(container_collection, self.data)
 

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -48,11 +48,7 @@ class ExtractBlend(publish.Extractor):
         # Substitute objects by their collections to avoid data duplication
         collections = set(plugin.get_collections_by_objects(data_blocks))
         if collections:
-            data_blocks = collections | {
-                d
-                for d in data_blocks
-                if isinstance(d, tuple(BL_OUTLINER_TYPES))
-            }
+            data_blocks.update(collections)
 
         # Get images used by datablocks and process resources
         used_images = self._get_used_images(data_blocks)


### PR DESCRIPTION
- Made `draw_gather_into_collection` into one function because it's shared by two operators.
- Changed condition to be `True` if `Collection` is a type handled by the family, which is more accurate than expecting `BL_OUTLINER_TYPES` to be all handled.
- Simplified blend extraction.

### How to test
Regular use of `Gather into collection`.