### PR TITLE
Fix: Camera instance creation with gather into collection

### DIFF
--- a/openpype/hosts/blender/plugins/create/create_camera.py
+++ b/openpype/hosts/blender/plugins/create/create_camera.py
@@ -16,7 +16,7 @@ class CreateCamera(plugin.Creator):
     icon = "video-camera"
 
     def process(
-        self, datablocks: List[bpy.types.ID] = None
+        self, datablocks: List[bpy.types.ID] = None, **kwargs
     ) -> OpenpypeInstance:
         # Create instance object
         asset = self.data["asset"]
@@ -36,4 +36,4 @@ class CreateCamera(plugin.Creator):
             datablocks.append(camera_obj)
 
         # Create Instance
-        return super().process(datablocks)
+        return super().process(datablocks, **kwargs)


### PR DESCRIPTION
## Brief description
Because of wrong argument instance creation was failing.

## Testing notes:
1. Create camera instance with gather into collection