### PR TITLE
Fix: published source paths are lower cased

### DIFF
--- a/openpype/pipeline/anatomy.py
+++ b/openpype/pipeline/anatomy.py
@@ -1126,7 +1126,7 @@ class RootItem(FormatObject):
             if _mod_path.startswith(root_path):
                 result = True
                 replacement = "{" + self.full_key() + "}"
-                output = replacement + _mod_path[len(root_path):]
+                output = replacement + mod_path[len(root_path):]
                 break
 
         return (result, output)


### PR DESCRIPTION
## Brief description
This is a fix applied from core OP. Source paths have lower case at publish, which could make the sync server fail or publish at the wrong place.