### PR TITLE
Fix: camera create by matching camera from datablocks and all children

### DIFF
--- a/openpype/hosts/blender/plugins/create/create_camera.py
+++ b/openpype/hosts/blender/plugins/create/create_camera.py
@@ -8,6 +8,29 @@ from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.properties import OpenpypeInstance
 from openpype.hosts.blender.api.utils import get_all_outliner_children
 
+def _get_camera_from_datablocks(datablocks: List[bpy.types.ID])->Union[bpy.types.Object, None]:
+    """Get first camera found in given datablocks list.
+
+    Args:
+        datablocks (List[bpy.types.ID]):
+            List of datablocks to get camera from
+
+    Returns:
+        Union[bpy.types.Object, None]: Found camera if any.
+    """
+    outliner_children = set(
+        chain.from_iterable(
+            get_all_outliner_children(d) for d in datablocks
+        )
+    )
+    return next(
+        (
+            c
+            for c in outliner_children | set(datablocks)
+            if isinstance(c, bpy.types.Object) and c.type == "CAMERA"
+        ),
+        None,
+    )
 
 class CreateCamera(plugin.Creator):
     """Single baked camera"""
@@ -16,31 +39,6 @@ class CreateCamera(plugin.Creator):
     label = "Camera"
     family = "camera"
     icon = "video-camera"
-
-    @staticmethod
-    def _get_camera_from_datablocks(datablocks: List[bpy.types.ID])->Union[bpy.types.Object, None]:
-        """Get first camera found in given datablocks list.
-
-        Args:
-            datablocks (List[bpy.types.ID]):
-                List of datablocks to get camera from
-
-        Returns:
-            Union[bpy.types.Object, None]: Found camera if any.
-        """
-        outliner_children = set(
-            chain.from_iterable(
-                get_all_outliner_children(d) for d in datablocks
-            )
-        )
-        return next(
-            (
-                c
-                for c in outliner_children | set(datablocks)
-                if isinstance(c, bpy.types.Object) and c.type == "CAMERA"
-            ),
-            None,
-        )
 
     def process(
         self, datablocks: List[bpy.types.ID] = None, **kwargs
@@ -52,7 +50,7 @@ class CreateCamera(plugin.Creator):
 
         # Rename existing camera or create one
         datablocks = datablocks or []
-        camera = self._get_camera_from_datablocks(datablocks)
+        camera = _get_camera_from_datablocks(datablocks)
         if camera:
             camera.name = instance_name
             camera.data.name = instance_name

--- a/openpype/hosts/blender/plugins/create/create_camera.py
+++ b/openpype/hosts/blender/plugins/create/create_camera.py
@@ -1,10 +1,12 @@
 """Create a camera asset."""
 
-from typing import List
+from itertools import chain
+from typing import List, Union
 import bpy
 
 from openpype.hosts.blender.api import plugin
 from openpype.hosts.blender.api.properties import OpenpypeInstance
+from openpype.hosts.blender.api.utils import get_all_outliner_children
 
 
 class CreateCamera(plugin.Creator):
@@ -14,6 +16,31 @@ class CreateCamera(plugin.Creator):
     label = "Camera"
     family = "camera"
     icon = "video-camera"
+
+    @staticmethod
+    def _get_camera_from_datablocks(datablocks: List[bpy.types.ID])->Union[bpy.types.Object, None]:
+        """Get first camera found in given datablocks list.
+
+        Args:
+            datablocks (List[bpy.types.ID]):
+                List of datablocks to get camera from
+
+        Returns:
+            Union[bpy.types.Object, None]: Found camera if any.
+        """
+        outliner_children = set(
+            chain.from_iterable(
+                get_all_outliner_children(d) for d in datablocks
+            )
+        )
+        return next(
+            (
+                c
+                for c in outliner_children | set(datablocks)
+                if isinstance(c, bpy.types.Object) and c.type == "CAMERA"
+            ),
+            None,
+        )
 
     def process(
         self, datablocks: List[bpy.types.ID] = None, **kwargs
@@ -25,11 +52,10 @@ class CreateCamera(plugin.Creator):
 
         # Rename existing camera or create one
         datablocks = datablocks or []
-        for obj in datablocks:
-            if obj and obj.type == "CAMERA":
-                obj.name = instance_name
-                obj.data.name = instance_name
-                break
+        camera = self._get_camera_from_datablocks(datablocks)
+        if camera:
+            camera.name = instance_name
+            camera.data.name = instance_name
         else:
             camera = bpy.data.cameras.new(instance_name)
             camera_obj = bpy.data.objects.new(instance_name, camera)


### PR DESCRIPTION
## Brief description
Camera wasn't matched from children of target object and then one was created even though one was in a targeted collection.

## Testing notes:
1. Create a camera inside a collection
2. Create camera instance by pointing the collection
3. The collection is converted as a camera instance one, but no new camera is created.