### PR TITLE
Fix: published images resources incorrectly mapped

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -121,7 +121,6 @@ class ExtractBlend(publish.Extractor):
         bpy.data.libraries.write(
             filepath.as_posix(),
             datablocks,
-            path_remap="ABSOLUTE",
             fake_user=True,
             compress=get_compress_setting(),
         )
@@ -169,8 +168,8 @@ class ExtractBlend(publish.Extractor):
             if img.source in {"FILE", "SEQUENCE", "MOVIE"}
             and not img.packed_file
         }:
-            # Check image is not internal
-            if not image.filepath:
+            # Skip image from library or internal
+            if image.library or not image.filepath:
                 continue
 
             # Get source and destination paths


### PR DESCRIPTION
## Brief description
- Published images are incorrectly remapped when copied into `resources` because the `ABSOLUTE` param was remapping from the source file and not the published one. This way they remain relative.
- Also fixed blocked publish with relative paths from libraries, they was considered as images required for the current file when they are not.

## Testing notes:
1. Create a branch from normaal/master with merging this fix
1. Publish lookdev with texture
2. Load this look, assign it to a new model and publish it
3. Load the model