### PR TITLE
Feature: Duplicate openpype instance operator

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -802,7 +802,7 @@ class SCENE_OT_DuplicateOpenpypeInstance(
 
         # Guess basename and extension
         split_name = active_instance.name.rsplit(".", 1)
-        if len(split_name) > 1:
+        if len(split_name) > 1 and split_name[1].isdigit():
             basename, number = split_name
             extension_i = int(number) + 1
         else:

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1,6 +1,7 @@
 """Blender operators and menus for use with Avalon."""
 
 import os
+from string import digits
 import sys
 import platform
 import time
@@ -26,6 +27,7 @@ from openpype.hosts.blender.api.lib import add_datablocks_to_container, update_s
 from openpype.hosts.blender.api.utils import (
     BL_OUTLINER_TYPES,
     BL_TYPE_DATAPATH,
+    build_op_basename,
     get_all_outliner_children,
     get_parent_collection,
     link_to_collection,
@@ -507,6 +509,13 @@ class ManageOpenpypeInstance:
         description="Gather outliner entities when added to instance under single collection",
     )
 
+    def draw_variant_name(self):
+        """Draw variant name with defaults selection list."""
+        # Variant with defaults list
+        sublayout = self.layout.row(align=True)
+        sublayout.prop(self, "variant_name")
+        sublayout.prop(self, "variant_default", icon_only=True)
+
 
 class SCENE_OT_CreateOpenpypeInstance(
     ManageOpenpypeInstance, bpy.types.Operator
@@ -539,9 +548,7 @@ class SCENE_OT_CreateOpenpypeInstance(
         layout.prop_search(self, "asset_name", self, "all_assets")
 
         # Variant with defaults list
-        sublayout = layout.row(align=True)
-        sublayout.prop(self, "variant_name")
-        sublayout.prop(self, "variant_default", icon_only=True)
+        self.draw_variant_name()
 
         # Subset name preview
         sublayout = layout.row()
@@ -771,41 +778,96 @@ class SCENE_OT_RemoveFromOpenpypeInstance(
         return {"FINISHED"}
 
 
-class SCENE_OT_DuplicateOpenpypeInstance(bpy.types.Operator):
+class SCENE_OT_DuplicateOpenpypeInstance(
+    ManageOpenpypeInstance, bpy.types.Operator
+):
     """Duplicate OpenPype instance"""
 
     bl_idname = "scene.duplicate_openpype_instance"
     bl_label = "Duplicate OpenPype Instance"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return context.scene.openpype_instance_active_index >= 0
+
+    def invoke(self, context, _event):
+        wm = context.window_manager
+
+        # Get active instance
+        op_instances = context.scene.openpype_instances
+        active_instance = op_instances[
+            context.scene.openpype_instance_active_index
+        ]
+
+        # Guess basename and extension
+        split_name = active_instance.name.rsplit(".", 1)
+        if len(split_name) > 1:
+            basename, number = split_name
+            extension_i = int(number) + 1
+        else:
+            basename = split_name[0]
+            extension_i = 1
+
+        # Increment extension based on existing ones
+        while op_instances.get(f"{basename}.{str(extension_i).zfill(3)}"):
+            extension_i += 1
+        else:
+            extension = str(extension_i).zfill(3)
+
+        # Prefill variant name
+        subset_basename = (
+            active_instance["avalon"]["subset"]
+            .rstrip(f".{digits}")
+            .replace(active_instance["avalon"]["family"], "")
+        )
+        self.variant_name = f"{subset_basename}.{extension}"
+
+        return wm.invoke_props_dialog(self)
+
+    def draw(self, _context):
+        # Variant with defaults list
+        self.draw_variant_name()
+
     def execute(self, context):
         op_instances = context.scene.openpype_instances
-
-        # Create new intance
-        new_instance = op_instances.add()
 
         # Get active instance
         active_instance = op_instances[
             context.scene.openpype_instance_active_index
         ]
 
+        # Build subset name
+        project_name = legacy_io.active_project()
+        asset_name = active_instance["avalon"]["asset"]
+        subset_name = get_subset_name(
+            active_instance["avalon"]["family"],
+            self.variant_name,
+            legacy_io.Session["AVALON_TASK"],
+            get_asset_by_name(project_name, asset_name, fields=["_id"]),
+            project_name,
+        )
+
+        # Check name
+        new_instance_name = build_op_basename(asset_name, subset_name)
+        if active_instance.name == new_instance_name:
+            self.report(
+                {"ERROR"},
+                f"Duplicate instance cannot have same name as original: {new_instance_name}",
+            )
+            return {"CANCELLED"}
+
+        # Create new instance
+        new_instance = op_instances.add()
+        new_instance.name = new_instance_name
+
         # Apply metadata
         # NOTE hardcoded because strange behaviour with .items()
         for k in ["avalon", "creator_name", "icons"]:
             new_instance[k] = active_instance.get(k)
 
-        # Change name
-        split_name = active_instance.name.rsplit(".", 1)
-        if len(split_name) > 1:
-            basename, number = split_name
-            extension = str(int(number) + 1).zfill(3)
-        else:
-            basename = split_name[0]
-            extension = "001"
-        new_instance.name = f"{basename}.{extension}"
-        new_instance["avalon"][
-            "subset"
-        ] = f'{active_instance["avalon"]["subset"]}.{extension}'
+        # Update subset name
+        new_instance["avalon"]["subset"] = subset_name
 
         # Assign datablocks
         add_datablocks_to_container(

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -20,6 +20,7 @@ from openpype.hosts.blender.api.utils import (
     BL_OUTLINER_TYPES,
     BL_TYPE_DATAPATH,
     BL_TYPE_ICON,
+    build_op_basename,
     get_children_recursive,
     get_parent_collection,
     link_to_collection,
@@ -48,17 +49,6 @@ from .pipeline import metadata_update, AVALON_PROPERTY
 VALID_EXTENSIONS = [".blend", ".json", ".abc", ".fbx"]
 
 log = Logger.get_logger(__name__)
-
-
-def build_op_basename(
-    asset: str, subset: str, namespace: Optional[str] = None
-) -> str:
-    """Return a consistent name for an asset."""
-    name = f"{asset}"
-    if namespace:
-        name = f"{name}_{namespace}"
-    name = f"{name}_{subset}"
-    return name
 
 
 def get_unique_number(

--- a/openpype/hosts/blender/api/ui.py
+++ b/openpype/hosts/blender/api/ui.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.types import UIList
+from bpy.types import Menu, UIList
 from openpype.hosts.blender.api.utils import BL_TYPE_DATAPATH, BL_TYPE_ICON
 
 
@@ -68,6 +68,16 @@ class SCENE_UL_OpenpypeDatablocks(UIList):
         row.label(text=item.name, icon=icon)
 
 
+
+class SCENE_MT_openpype_instances_context_menu(Menu):
+    bl_label = "Vertex Group Specials"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("scene.duplicate_openpype_instance", icon='DUPLICATE')
+
+
 class SCENE_PT_OpenpypeInstancesManager(bpy.types.Panel):
     bl_label = "OpenPype Instances Manager"
     bl_space_type = "PROPERTIES"
@@ -82,7 +92,7 @@ class SCENE_PT_OpenpypeInstancesManager(bpy.types.Panel):
             layout.operator("scene.create_openpype_instance", icon="ADD")
             return
 
-        row = layout.row(align=True)
+        row = layout.row()
         ob = context.scene
 
         # List of OpenPype instances
@@ -105,6 +115,10 @@ class SCENE_PT_OpenpypeInstancesManager(bpy.types.Panel):
         col.operator(
             "scene.remove_openpype_instance", icon="REMOVE", text=""
         ).instance_name = active_instance.name
+
+        col.separator()
+
+        col.menu("SCENE_MT_openpype_instances_context_menu", icon='DOWNARROW_HLT', text="")
 
         col.separator()
 
@@ -202,6 +216,7 @@ classes = (
     SCENE_PT_OpenpypeDatablocksManager,
     SCENE_UL_OpenpypeInstances,
     SCENE_UL_OpenpypeDatablocks,
+    SCENE_MT_openpype_instances_context_menu,
 )
 
 register, unregister = bpy.utils.register_classes_factory(classes)

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -36,6 +36,17 @@ BL_TYPE_ICON = {
 BL_OUTLINER_TYPES = frozenset((bpy.types.Collection, bpy.types.Object))
 
 
+def build_op_basename(
+    asset: str, subset: str, namespace: Optional[str] = None
+) -> str:
+    """Return a consistent name for an asset."""
+    name = f"{asset}"
+    if namespace:
+        name = f"{name}_{namespace}"
+    name = f"{name}_{subset}"
+    return name
+
+
 def get_children_recursive(
     entity: Union[bpy.types.Collection, bpy.types.Object]
 ) -> Iterator[Union[bpy.types.Collection, bpy.types.Object]]:


### PR DESCRIPTION
## Brief description
- Duplicated with `.xxx` extension.
- Changed the UI of instance creation.

## Testing notes:
1. Create an instance
2. In context menu, duplicate the instance