### PR TITLE
Fix: Gather into collection checkbox display

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -741,7 +741,7 @@ def draw_gather_into_collection(self, context):
         for t in context.scene["openpype_creators"][self.creator_name][
             "bl_types"
         ]
-    }:
+    } or self.use_selection:
         self.layout.prop(self, "gather_into_collection")
 
 


### PR DESCRIPTION
## Brief description
Gather into collection was hidden even if use selection is check. It must be accessible in this configuration.
