### PR TITLE
Enhancement: Set object mode on extract blend

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -41,6 +41,9 @@ class ExtractBlend(publish.Extractor):
         # Perform extraction
         self.log.info("Performing extraction..")
 
+        # Set object mode
+        bpy.ops.object.mode_set()
+
         plugin.deselect_all()
 
         data_blocks = set(instance)


### PR DESCRIPTION
# Description
Set object mode on extract blend, so publishing from another mode doesn't cause errors anymore. That way artists don't have to manually set object mode before their publish, if they work in another mode.

# Testing
- Disable validate object mode validator or use a context in which it's disabled (animation for instance)
- Set an object in another mode than object mode
- Publish