### PR TITLE
Fix: Container representation ID overridden by update_representations

### DIFF
--- a/openpype/hosts/blender/plugins/publish/collect_instances.py
+++ b/openpype/hosts/blender/plugins/publish/collect_instances.py
@@ -6,6 +6,7 @@ import bpy
 
 import pyblish.api
 from openpype.hosts.blender.api.utils import (
+    BL_OUTLINER_TYPES,
     BL_TYPE_DATAPATH,
 )
 from openpype.pipeline import AVALON_CONTAINER_ID, AVALON_INSTANCE_ID
@@ -100,8 +101,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
             # Add datablocks used by the main datablocks
             non_outliner_datacols = set(
                 chain.from_iterable(
-                    getattr(bpy.data, t)
-                    for t in BL_TYPE_DATAPATH.values()
+                    getattr(bpy.data, datacol)
+                    for bl_type, datacol in BL_TYPE_DATAPATH.items()
+                    if bl_type not in BL_OUTLINER_TYPES
                 )
             )
             members.update(
@@ -114,10 +116,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 }
             )
 
-            # Add instance holder as first item
-            members = list(members)
-
-            instance[:] = members
+            # Fill instance with members
+            instance[:] = list(members)
             self.log.debug(json.dumps(instance.data, indent=4))
             for obj in instance:
                 self.log.debug(obj)

--- a/openpype/hosts/blender/utility_scripts/update_representations.py
+++ b/openpype/hosts/blender/utility_scripts/update_representations.py
@@ -6,7 +6,10 @@ from openpype.client.entities import (
     get_asset_by_name,
     get_subset_by_name,
 )
-from openpype.hosts.blender.api.pipeline import metadata_update
+from openpype.hosts.blender.api.pipeline import (
+    AVALON_PROPERTY,
+    metadata_update,
+)
 from openpype.pipeline import legacy_io
 from openpype.pipeline.constants import AVALON_CONTAINER_ID
 
@@ -50,7 +53,11 @@ if __name__ == "__main__":
     for datapath in args.datapaths:
         for datablock_name in args.datablocks:
             datablock = getattr(bpy.data, datapath).get(datablock_name)
-            if not datablock or datablock in containerized_datablocks:
+            if (
+                not datablock
+                or datablock in containerized_datablocks
+                or datablock.get(AVALON_PROPERTY, {}).get("representation")
+            ):
                 continue
 
             # Get docs


### PR DESCRIPTION
## Brief description
Expose container content works fine. It's the container which have the wrong representation id, because it has been overridden during `update_representations` process. That's because the container collections are appended in the instance when they shouldn't.

## Description
- Collect instances: Ensured datablocks added to instance are not outliner type to avoid useless nested collections
- Update instances: If a datablock already has a `representation` key, it is skipped.

## Testing notes:
1. publish a layout
2. load layout and `expose container content`
3. All contents must be referenced