### PR TITLE
Fix: action not user remapped

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1236,6 +1236,14 @@ class AssetLoader(Loader):
                     new_datablock.name = old_datablock["original_name"]
                     old_datablock.user_remap(new_datablock)
 
+                    # Ensure action remap, due to bug
+                    # https://projects.blender.org/blender/blender/issues/104576
+                    # TODO remove when fixed
+                    if hasattr(old_datablock, "animation_data") and old_datablock.animation_data:
+                        if not new_datablock.animation_data:
+                            new_datablock.animation_data_create()
+                        new_datablock.animation_data.action = old_datablock.animation_data.action
+
             # Restore parent collection if existing
             if parent_collection:
                 unlink_from_collection(

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1236,9 +1236,7 @@ class AssetLoader(Loader):
                     new_datablock.name = old_datablock["original_name"]
                     old_datablock.user_remap(new_datablock)
 
-                    # Ensure action remap, due to bug
-                    # https://projects.blender.org/blender/blender/issues/104576
-                    # TODO remove when fixed
+                    # Ensure action relink
                     if hasattr(old_datablock, "animation_data") and old_datablock.animation_data:
                         if not new_datablock.animation_data:
                             new_datablock.animation_data_create()

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1237,10 +1237,15 @@ class AssetLoader(Loader):
                     old_datablock.user_remap(new_datablock)
 
                     # Ensure action relink
-                    if hasattr(old_datablock, "animation_data") and old_datablock.animation_data:
+                    if (
+                        hasattr(old_datablock, "animation_data")
+                        and old_datablock.animation_data
+                    ):
                         if not new_datablock.animation_data:
                             new_datablock.animation_data_create()
-                        new_datablock.animation_data.action = old_datablock.animation_data.action
+                        new_datablock.animation_data.action = (
+                            old_datablock.animation_data.action
+                        )
 
             # Restore parent collection if existing
             if parent_collection:


### PR DESCRIPTION
## Brief description
Due to a [blender bug](https://projects.blender.org/blender/blender/issues/104576), action is not remapped. This is a temporary fix.

## Testing notes:
1. Link a model container
2. Assign an action to an object
3. Switch the model to `Append`, the action is maintained.