### PR TITLE
Fix: get_all_outliner_children to accept only outliner types

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -73,8 +73,11 @@ def get_all_outliner_children(
     """
     if not entity:
         return set()
-
-    if hasattr(entity, "all_objects"):
+    elif not isinstance(entity, tuple(BL_OUTLINER_TYPES)):
+        raise ValueError(
+            f"{entity} is not an accepted outliner type: {BL_OUTLINER_TYPES}"
+        )
+    elif hasattr(entity, "all_objects"):
         return set(entity.children_recursive) | set(entity.all_objects)
     else:
         return set(entity.children_recursive)

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -74,7 +74,7 @@ def get_all_outliner_children(
     if not entity:
         return set()
     elif not isinstance(entity, tuple(BL_OUTLINER_TYPES)):
-        raise ValueError(
+        raise TypeError(
             f"{entity} is not an accepted outliner type: {BL_OUTLINER_TYPES}"
         )
     elif hasattr(entity, "all_objects"):


### PR DESCRIPTION
## Brief description
In case we are passing a non-outliner type in `get_all_outliner_children`, we get a confusing error message, as "entity has no attribute 'children_recursive', when it's a type error we must clarify."

## Testing notes:
1. Pass a non-outliner type to the function, anything but a collection or an object