### PR TITLE
Fix: same name matched but different type

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1225,7 +1225,8 @@ class AssetLoader(Loader):
                     (
                         d
                         for d in datablocks
-                        if old_datablock["original_name"].rstrip(f".{digits}")
+                        if type(d) is type(old_datablock)
+                        and old_datablock["original_name"].rstrip(f".{digits}")
                         == d.name.rstrip(f".{digits}")
                     ),
                     None,


### PR DESCRIPTION
## Brief description
In case of loaded datablocks have same name but same type, they might be confounded.

## Testing notes:
1. Publish instance which has the same name of one of its nested objects
2. Load it and switch or update it