### PR TITLE
Fix: ReferenceError when making paths absolute

### DIFF
--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
                     ).resolve()
                 )
                 datablock.reload()
-            except RuntimeError as e:
+            except (RuntimeError, ReferenceError) as e:
                 log.error(e)
     else:
         bpy.ops.file.make_paths_absolute()


### PR DESCRIPTION
## Brief description
It may happen that `image` object doesn't exist any more but still processed raising a `ReferenceError`.

## Testing notes:
1. Open any shot using the launcher.