### PR TITLE
Fix: expose_container_content with correct object relink if substitute collection

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1069,8 +1069,9 @@ class SCENE_OT_ExposeContainerContent(bpy.types.Operator):
         openpype_containers = context.scene.openpype_containers
         container = openpype_containers.get(self.container_name)
 
-        # In collection, convert to basic
+        # If collection, convert it to regular one
         parent_collection = get_parent_collection(container.outliner_entity)
+        substitute_collection = None
         if isinstance(container.outliner_entity, bpy.types.Collection):
             container.outliner_entity.name += ".old"
             if isinstance(container.outliner_entity, bpy.types.Collection):
@@ -1082,10 +1083,13 @@ class SCENE_OT_ExposeContainerContent(bpy.types.Operator):
                     container.outliner_entity.children, substitute_collection
                 )
 
-        # Unlink entity from scene
+        # Move objects to either substituted collection or the parent one
         link_to_collection(
-            container.outliner_entity.objects, parent_collection
+            container.outliner_entity.objects,
+            substitute_collection or parent_collection,
         )
+
+        # Unlink entity from scene
         parent_collection.children.unlink(container.outliner_entity)
         container.outliner_entity.use_fake_user = False
 

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -1074,18 +1074,21 @@ class SCENE_OT_ExposeContainerContent(bpy.types.Operator):
         substitute_collection = None
         if isinstance(container.outliner_entity, bpy.types.Collection):
             container.outliner_entity.name += ".old"
-            if isinstance(container.outliner_entity, bpy.types.Collection):
-                substitute_collection = bpy.data.collections.new(
-                    self.container_name
-                )
-                parent_collection.children.link(substitute_collection)
-                link_to_collection(
-                    container.outliner_entity.children, substitute_collection
-                )
+            substitute_collection = bpy.data.collections.new(
+                self.container_name
+            )
+
+            # Link old collection objects to new substitute collection
+            link_to_collection(
+                container.outliner_entity.objects, substitute_collection
+            )
+
+            # Link new substitute collection to parent collection
+            parent_collection.children.link(substitute_collection)
 
         # Move objects to either substituted collection or the parent one
         link_to_collection(
-            container.outliner_entity.objects,
+            container.outliner_entity.children,
             substitute_collection or parent_collection,
         )
 


### PR DESCRIPTION
## Brief description
When doing a `expose_container_content`, if a substitute collection is created, object content was not correctly relinked to created collection, was always moved to parent collection.

## Testing notes:
1. Load a simple container which has only objects into its collection
2. Run `expose_container_content`