### PR TITLE
Fix: Camera hidden in viewport breaks modeset in extract blend

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -40,12 +40,21 @@ class ExtractBlend(publish.Extractor):
         # Perform extraction
         self.log.info("Performing extraction..")
 
+        # Make camera visible in viewport
+        camera = bpy.context.scene.camera
+        is_camera_hidden_viewport = camera.hide_viewport
+        camera.hide_viewport = False
+
         # Set object mode
         with plugin.context_override(
             active=bpy.context.scene.objects[0],
             selected=bpy.context.scene.objects,
         ):
             bpy.ops.object.mode_set()
+
+        # Set camera hide in viewport back to its original value
+        if is_camera_hidden_viewport:
+            camera.hide_viewport = True
 
         plugin.deselect_all()
 


### PR DESCRIPTION
## Description
Fixing object mode_set failing if the camera is hidden in viewport.

## Testing
- Open an asset with a camera instance.
- Hide the camera in viewport.
- Extract blend and extract workfile should pass.
- Camera hide in viewport should have its original value after publish.