### PR TITLE
Enhancement: Allowing kitsu note status exceptions

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -44,7 +44,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 )
 
         # Add comment to kitsu task
-        self.log.debug("Add new note in taks id {}".format(kitsu_task["id"]))
+        self.log.debug("Add new note in tasks id {}".format(kitsu_task["id"]))
         kitsu_comment = gazu.task.add_comment(
             kitsu_task, note_status, comment=publish_comment
         )

--- a/openpype/settings/defaults/project_settings/kitsu.json
+++ b/openpype/settings/defaults/project_settings/kitsu.json
@@ -7,7 +7,8 @@
     "publish": {
         "IntegrateKitsuNote": {
             "set_status_note": false,
-            "note_status_shortname": "wfa"
+            "note_status_shortname": "wfa",
+            "status_exceptions": []
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
@@ -52,6 +52,12 @@
                             "type": "text",
                             "key": "note_status_shortname",
                             "label": "Note shortname"
+                        },
+                        {
+                            "type": "list",
+                            "object_type": "text",
+                            "key": "status_exceptions",
+                            "label": "Status exceptions shortnames"
                         }
                     ]
                 }


### PR DESCRIPTION
## Description
Adding a setting to choose some statuses that should not be changed by `IntegrateKitsuNote`.

## Testing
- Go to project settings -> Kitsu -> Publish
- With integrate kitsu note active, add any status shortname that should be left untouched (careful: it's case sensitive)
- Set one of those statuses on the task you want to use for testing on kitsu
- Publish this task
- The status should not have changed