### PR TITLE
Fix: Extract workfile (Blender) fails if there's no camera in the scene

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -42,8 +42,11 @@ class ExtractBlend(publish.Extractor):
 
         # Make camera visible in viewport
         camera = bpy.context.scene.camera
-        is_camera_hidden_viewport = camera.hide_viewport
-        camera.hide_viewport = False
+        if camera:
+            is_camera_hidden_viewport = camera.hide_viewport
+            camera.hide_viewport = False
+        else:
+            is_camera_hidden_viewport = False
 
         # Set object mode
         with plugin.context_override(


### PR DESCRIPTION
## Description
Extract workfile (Blender) fails if there's no camera in the scene.

## Testing
- Publish a workfile with no camera in the scene
- `Extract workfile` should not fail 