### PR TITLE
Fix: active object is library override

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -50,7 +50,14 @@ class ExtractBlend(publish.Extractor):
 
         # Set object mode
         with plugin.context_override(
-            active=bpy.context.scene.objects[0],
+            active=next(  # Get first object that is not library override
+                (
+                    o
+                    for o in bpy.context.scene.objects
+                    if o.override_library is None
+                ),
+                None,
+            ),
             selected=bpy.context.scene.objects,
         ):
             bpy.ops.object.mode_set()


### PR DESCRIPTION
## Brief description
If active object is library override, the operator fails.

## Testing notes:
1. Can test to publish fworkfile with `e108_sq009_e108_sh055`