### PR TITLE
Fix extract_blend set object mode

### DIFF
--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -49,13 +49,17 @@ class ExtractBlend(publish.Extractor):
             is_camera_hidden_viewport = False
 
         # Set object mode if some objects are not.
-        not_object_mode_objs = [obj for obj in bpy.context.scene.objects]
+        not_object_mode_objs = [
+            obj
+            for obj in bpy.context.scene.objects
+            if obj.mode != "OBJECT"
+        ]
         if not_object_mode_objs:
-                with plugin.context_override(
-                    active=not_object_mode_objs[0],
-                    selected=not_object_mode_objs,
-                ):
-                    bpy.ops.object.mode_set()
+            with plugin.context_override(
+                active=not_object_mode_objs[0],
+                selected=not_object_mode_objs,
+            ):
+                bpy.ops.object.mode_set()
 
         # Set camera hide in viewport back to its original value
         if is_camera_hidden_viewport:

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -50,17 +50,19 @@ class ExtractBlend(publish.Extractor):
 
         # Set object mode
         with plugin.context_override(
-            active=next(  # Get first object that is not library override
+            # Get first visible object that is not library override
+            active=next(
                 (
                     o
                     for o in bpy.context.scene.objects
-                    if o.override_library is None
+                    if o.override_library is None and o.visible_get()
                 ),
                 None,
             ),
             selected=bpy.context.scene.objects,
         ):
-            bpy.ops.object.mode_set()
+            if bpy.ops.object.mode_set.poll():  # last safty check
+                bpy.ops.object.mode_set()
 
         # Set camera hide in viewport back to its original value
         if is_camera_hidden_viewport:

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -48,21 +48,16 @@ class ExtractBlend(publish.Extractor):
         else:
             is_camera_hidden_viewport = False
 
-        # Set object mode
-        with plugin.context_override(
-            # Get first visible object that is not library override
-            active=next(
-                (
-                    o
-                    for o in bpy.context.scene.objects
-                    if o.override_library is None and o.visible_get()
-                ),
-                None,
-            ),
-            selected=bpy.context.scene.objects,
-        ):
-            if bpy.ops.object.mode_set.poll():  # last safty check
-                bpy.ops.object.mode_set()
+        # Set object mode if some objects are not.
+        for obj in bpy.context.scene.objects:
+            if obj.mode != "OBJECT":
+                with plugin.context_override(
+                    active=obj,
+                    selected=bpy.context.scene.objects,
+                ):
+                    if bpy.ops.object.mode_set.poll():  # safty check
+                        bpy.ops.object.mode_set()
+                        break
 
         # Set camera hide in viewport back to its original value
         if is_camera_hidden_viewport:

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -55,9 +55,7 @@ class ExtractBlend(publish.Extractor):
                     active=obj,
                     selected=bpy.context.scene.objects,
                 ):
-                    if bpy.ops.object.mode_set.poll():  # safty check
-                        bpy.ops.object.mode_set()
-                        break
+                    bpy.ops.object.mode_set()
 
         # Set camera hide in viewport back to its original value
         if is_camera_hidden_viewport:

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -49,11 +49,11 @@ class ExtractBlend(publish.Extractor):
             is_camera_hidden_viewport = False
 
         # Set object mode if some objects are not.
-        for obj in bpy.context.scene.objects:
-            if obj.mode != "OBJECT":
+        not_object_mode_objs = [obj for obj in bpy.context.scene.objects]
+        if not_object_mode_objs:
                 with plugin.context_override(
-                    active=obj,
-                    selected=bpy.context.scene.objects,
+                    active=not_object_mode_objs[0],
+                    selected=not_object_mode_objs,
                 ):
                     bpy.ops.object.mode_set()
 


### PR DESCRIPTION
## Description
Prevent error with blend file with only objects with override library or hidden objects.
