### PR TITLE
Fix: update representation sets wrong parent ID

### DIFF
--- a/openpype/hosts/blender/utility_scripts/update_representations.py
+++ b/openpype/hosts/blender/utility_scripts/update_representations.py
@@ -4,6 +4,7 @@ import sys
 import bpy
 from openpype.client.entities import (
     get_asset_by_name,
+    get_representation_by_id,
     get_subset_by_name,
 )
 from openpype.hosts.blender.api.pipeline import (
@@ -47,7 +48,7 @@ if __name__ == "__main__":
         help="representation ID",
         required=True,
     )
-    args = parser.parse_args(sys.argv[sys.argv.index("--") + 1 :])
+    args, unknown = parser.parse_known_args(sys.argv[sys.argv.index("--") + 1 :])
 
     containerized_datablocks = set()
     for datapath in args.datapaths:
@@ -71,6 +72,11 @@ if __name__ == "__main__":
                 asset_doc["_id"],
                 fields=["data.family"],
             )
+            representation_doc = get_representation_by_id(
+                project_name,
+                args.representation_id,
+                fields=["data", "parent"],
+            )
 
             # Update container metadata
             metadata_update(
@@ -81,7 +87,7 @@ if __name__ == "__main__":
                     "name": args.subset_name,
                     "representation": args.representation_id,
                     "asset_name": legacy_io.Session["AVALON_ASSET"],
-                    "parent": str(asset_doc["parent"]),
+                    "parent": str(representation_doc["parent"]),
                     "family": subset_doc["data"]["family"],
                     "namespace": "",
                 },


### PR DESCRIPTION
## Changelog Description
The `parent` ID was filled by the project ID and not the version ID, which is the actual parent of a representation. This was creating inconsistencies with switches executed by programming.

## Testing notes:
1. Publish anything
2. Open the published file
3. The relevant container datablock's `['avalon']['parent']` is accurate (check with Compas)
