### PR TITLE
Fix make path abs exceptions

### DIFF
--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -33,15 +33,16 @@ if __name__ == "__main__":
         )
         for datablock in datablocks_with_filepath:
             try:
-                datablock.filepath = str(
-                    Path(
-                        bpy.path.abspath(
-                            datablock.filepath,
-                            start=args.source_filepath.parent,
-                        )
-                    ).resolve()
-                )
-                datablock.reload()
+                if datablock and datablock.filepath.startswith("//"):
+                    datablock.filepath = str(
+                        Path(
+                            bpy.path.abspath(
+                                datablock.filepath,
+                                start=args.source_filepath.parent,
+                            )
+                        ).resolve()
+                    )
+                    datablock.reload()
             except (RuntimeError, ReferenceError, OSError) as e:
                 log.error(e)
     else:

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
                     ).resolve()
                 )
                 datablock.reload()
-            except (RuntimeError, ReferenceError) as e:
+            except (RuntimeError, ReferenceError, OSError) as e:
                 log.error(e)
     else:
         bpy.ops.file.make_paths_absolute()


### PR DESCRIPTION
## Changelog Description
Hook `pre_add_make_paths_absolute_arg` can raise error outside try exception.
- added `OSError` exception (`FileNotFoundError` raise one time with some images filepath but I can't get this error again)
- `if datablock and datablock.filepath.startswith("//"):` moved into try except statement because it can raise `ReferenceError`

