### PR TITLE
Fix: Update datablock with digits

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1220,8 +1220,8 @@ class AssetLoader(Loader):
                         d
                         for d in datablocks
                         if type(d) is type(old_datablock)
-                        and old_datablock["original_name"].rstrip(f".{digits}")
-                        == d.name.rstrip(f".{digits}")
+                        and old_datablock["original_name"].rsplit(".", 1)[0]
+                        == d.name.rsplit(".", 1)[0]
                     ),
                     None,
                 )


### PR DESCRIPTION
## Changelog Description
Issue with digits in names
```py
"truc_1.001".rstrip(f".{digits}" == "truc_"
"truc_2.001".rstrip(f".{digits}" == "truc_"
```
Fixed with `rsplit`