### PR TITLE
Fix: remap paths creates orphans datablocks

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -1,4 +1,6 @@
 """Shared functionalities for Blender files data manipulation."""
+import itertools
+from pathlib import Path
 from typing import List, Optional, Set, Union, Iterator
 from collections.abc import Iterable
 
@@ -312,3 +314,38 @@ def transfer_stack(
             }
             for attr in attributes:
                 setattr(target_data, attr, getattr(stack_datablock, attr))
+
+
+def make_paths_absolute(source_filepath: Path = None):
+    """Make all paths absolute for datablock in current blend file.
+
+    Args:
+        source_filepath (Path, optional): Filepath to remap paths from,
+            in case file copy has been executed without paths remapping.
+            Defaults to None.
+    """
+    # In case no source filepath try naive system
+    if not source_filepath:
+        bpy.ops.file.make_paths_absolute()
+        return
+
+    # Resolve path from source filepath with the relative filepath
+    for datablock in itertools.chain(bpy.data.libraries, bpy.data.images):
+        try:
+            if datablock and datablock.filepath.startswith("//"):
+                datablock.filepath = str(
+                    Path(
+                        bpy.path.abspath(
+                            datablock.filepath,
+                            start=source_filepath.parent,
+                        )
+                    ).resolve()
+                )
+                datablock.reload()
+        except (RuntimeError, ReferenceError, OSError) as e:
+            print(e)
+    else:
+        bpy.ops.file.make_paths_absolute()
+
+    # Purge orphaned datablocks
+    bpy.data.orphans_purge()

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -348,4 +348,4 @@ def make_paths_absolute(source_filepath: Path = None):
         bpy.ops.file.make_paths_absolute()
 
     # Purge orphaned datablocks
-    bpy.data.orphans_purge()
+    bpy.data.orphans_purge(do_recursive=True)

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import sys
 
 import bpy
+from openpype.hosts.blender.api.utils import make_paths_absolute
 
 from openpype.lib.log import Logger
 
@@ -27,29 +28,7 @@ if __name__ == "__main__":
     args = parser.parse_args(sys.argv[sys.argv.index("--") + 1 :])
 
     if args.source_filepath.is_file():
-        # Resolve path from source filepath with the relative filepath
-        datablocks_with_filepath = list(bpy.data.libraries) + list(
-            bpy.data.images
-        )
-        for datablock in datablocks_with_filepath:
-            try:
-                if datablock and datablock.filepath.startswith("//"):
-                    datablock.filepath = str(
-                        Path(
-                            bpy.path.abspath(
-                                datablock.filepath,
-                                start=args.source_filepath.parent,
-                            )
-                        ).resolve()
-                    )
-                    datablock.reload()
-            except (RuntimeError, ReferenceError, OSError) as e:
-                log.error(e)
-    else:
-        bpy.ops.file.make_paths_absolute()
-
-    # Purge orphaned datablocks
-    bpy.data.orphans_purge()
+        make_paths_absolute(args.source_filepath)
 
     if bpy.data.filepath:
         bpy.ops.wm.save_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -48,5 +48,8 @@ if __name__ == "__main__":
     else:
         bpy.ops.file.make_paths_absolute()
 
+    # Purge orphaned datablocks
+    bpy.data.orphans_purge()
+
     if bpy.data.filepath:
         bpy.ops.wm.save_mainfile()


### PR DESCRIPTION
## Changelog Description
After path remapping, orphaned datablocks may remain and create issue at saving.

- Moved `make_paths_absolute` to `utils.py` to be able to use it in other functions (used in pending features)

## Testing notes:
1. Test with the files that crash for Mathias, you know better
