### PR TITLE
Fix: make paths absolute creates duplicate libs

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -330,7 +330,7 @@ def make_paths_absolute(source_filepath: Path = None):
         return
 
     # Resolve path from source filepath with the relative filepath
-    for datablock in itertools.chain(bpy.data.libraries, bpy.data.images):
+    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
             if datablock and datablock.filepath.startswith("//"):
                 datablock.filepath = str(

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -32,3 +32,4 @@ if __name__ == "__main__":
 
     if bpy.data.filepath:
         bpy.ops.wm.save_mainfile()
+        bpy.ops.wm.revert_mainfile()


### PR DESCRIPTION
## Changelog Description
I don't understand clearly what's going on, but I think the remap creates duplicated libs and the `chain` was iterating through them because their reference is not burnt into a fixed object. It made these libs remapped twice with a strange path prefix.  
This way, it iterates only through the right ones.

Also, the `revert` operation makes sure to get rid of duplicate datablocks/libs after absolute remap.

## Testing notes:
1. I've observed this behaviour with Foret_ESTAB_001_A_JOUR
