### PR TITLE
Fix: Containers auto creation is not accurate

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -23,7 +23,7 @@ from openpype.client.entities import (
     get_asset_by_name,
     get_assets,
 )
-from openpype.hosts.blender.api.lib import add_datablocks_to_container, update_scene_containers_from_outliner
+from openpype.hosts.blender.api.lib import add_datablocks_to_container, update_scene_containers
 from openpype.hosts.blender.api.utils import (
     BL_OUTLINER_TYPES,
     BL_TYPE_DATAPATH,
@@ -1223,7 +1223,7 @@ class SCENE_OT_ExposeContainerContent(bpy.types.Operator):
         outliner_entity.use_fake_user = False
 
         # Update containers list
-        update_scene_containers_from_outliner()
+        update_scene_containers()
 
         return {"FINISHED"}
 


### PR DESCRIPTION
## Changelog Description
Made containers auto creation more precise to avoid duplication from nested containers or reference datablocks.

## Testing notes:
1. Open any scene with a dirty manage (a lot of same containers), like most of the environment workfiles
2. Execute this code:
```py
import bpy

from openpype.hosts.blender.api.lib import update_scene_containers
from openpype.pipeline.legacy_io import Session

project_name = Session["AVALON_PROJECT"]
session_name = f"{Session['AVALON_ASSET']} {Session['AVALON_TASK']}"

print("Resetting containers list...")

# Clear containers and reload
bpy.context.scene.openpype_containers.clear()
update_scene_containers()
```
3. Open manage, it must be much cleaner (one container by reference)
