### PR TITLE
Fix: Open Workfile without crash

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -329,7 +329,6 @@ def make_paths_absolute(source_filepath: Path = None):
         bpy.ops.file.make_paths_absolute()
         return
 
-    # Resolve path from source filepath with the relative filepath
     for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
             if datablock and datablock.filepath.startswith("//"):
@@ -341,11 +340,7 @@ def make_paths_absolute(source_filepath: Path = None):
                         )
                     ).resolve()
                 )
-                datablock.reload()
         except (RuntimeError, ReferenceError, OSError) as e:
             print(e)
-    else:
-        bpy.ops.file.make_paths_absolute()
 
-    # Purge orphaned datablocks
-    bpy.data.orphans_purge(do_recursive=True)
+    bpy.ops.file.make_paths_absolute()


### PR DESCRIPTION
## Changelog Description
It seems the `revert_mainfile` added recently is more reliable and sufficient. Also, it seems that `reload()` and purging orphans at this step were producing crashes.

## Testing notes:
1. Tested on `e104_sh015`, make sure to get rid of local workfiles.

**NB: tested on branch  `3.15.2-normaal.16` but should work on any branches**
