### PR TITLE
Fix: Add ref to instance duplicates instance

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -504,10 +504,7 @@ class Creator(LegacyCreator):
         # Get info from data and create name value.
         asset = self.data["asset"]
         subset = self.data["subset"]
-        name = ensure_unique_name(
-            build_op_basename(asset, subset),
-            bpy.context.scene.openpype_instances.keys(),
-        )
+        name = build_op_basename(asset, subset)
 
         # Use selected objects if useSelection is True
         if (self.options or {}).get("useSelection"):


### PR DESCRIPTION
## Changelog Description
Bug introduced in previous commit, assuming to `ensure_unique_name` for instances creation, while it is not the expected behaviour.

## Testing notes:
1. Add datablock reference to exisiting instance
