### PR TITLE
Draft: Feature: Copy resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,6 +35,7 @@ body:
       label: Version
       description: What version are you running? Look to OpenPype Tray
       options:
+        - 3.15.6
         - 3.15.6-nightly.3
         - 3.15.6-nightly.2
         - 3.15.6-nightly.1
@@ -134,7 +135,6 @@ body:
         - 3.14.1-nightly.1
         - 3.14.0
         - 3.14.0-nightly.1
-        - 3.13.1-nightly.3
     validations:
       required: true
   - type: dropdown

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -156,7 +156,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{root}/{hierarchy[0]}"],
             recursive_paths=False)
         levels = ar.get_assets(_filter)
-        master_level = levels[0].get_editor_property('object_path')
+        master_level = levels[0].get_full_name()
 
         hierarchy_dir = root
         for h in hierarchy:
@@ -168,7 +168,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
-        level = levels[0].get_editor_property('object_path')
+        level = levels[0].get_full_name()
 
         unreal.EditorLevelLibrary.save_all_dirty_levels()
         unreal.EditorLevelLibrary.load_level(level)

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -819,7 +819,7 @@ class LayoutLoader(plugin.Loader):
             recursive_paths=False)
         levels = ar.get_assets(filter)
 
-        layout_level = levels[0].get_editor_property('object_path')
+        layout_level = levels[0].get_full_name()
 
         EditorLevelLibrary.save_all_dirty_levels()
         EditorLevelLibrary.load_level(layout_level)
@@ -919,7 +919,7 @@ class LayoutLoader(plugin.Loader):
                 package_paths=[f"{root}/{ms_asset}"],
                 recursive_paths=False)
             levels = ar.get_assets(_filter)
-            master_level = levels[0].get_editor_property('object_path')
+            master_level = levels[0].get_full_name()
 
             sequences = [master_sequence]
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -186,7 +186,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         # Keep source filepath for further path conformation
         self.data["source_filepath"] = last_published_workfile_path
 
-        resources_dir = os.path.join(local_workfile_dir, 'resources')
+        resources_dir = os.path.join(os.path.dirname(local_workfile_path), 'resources')
         if not os.path.exists(resources_dir):
             os.mkdir(resources_dir)
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -188,13 +188,9 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         resources_dir = os.path.join(local_workfile_dir, 'resources')
         if not os.path.exists(resources_dir):
-            print(f"making dir {resources_dir}")
             os.mkdir(resources_dir)
 
         for file in workfile_representation['files']:
             resource_path = re.sub(r"\{root\[main\]\}", str(anatomy.roots['main']), file['path'])
             if os.path.exists(resource_path):
-                print(f"copying resource {resource_path}")
                 shutil.copy(resource_path, resources_dir)
-            else:
-                print(f"resource doesn't exist {resource_path}")

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -187,7 +187,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         self.data["source_filepath"] = last_published_workfile_path
 
         resources_dir = os.path.join(local_workfile_dir, 'resources')
-        if not os.path.exists(resource_dir):
+        if not os.path.exists(resources_dir):
             print(f"making dir {resources_dir}")
             os.mkdir(resources_dir)
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -186,11 +186,18 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         # Keep source filepath for further path conformation
         self.data["source_filepath"] = last_published_workfile_path
 
-        resources_dir = os.path.join(os.path.dirname(local_workfile_path), 'resources')
+        resources_dir = os.path.join(
+            os.path.dirname(local_workfile_path), 'resources'
+        )
         if not os.path.exists(resources_dir):
             os.mkdir(resources_dir)
 
         for file in workfile_representation['files']:
-            resource_path = re.sub(r"\{root\[main\]\}", str(anatomy.roots['main']), file['path'])
-            if os.path.exists(resource_path):
+            resource_path = re.sub(
+                r"\{root\[main\]\}", str(anatomy.roots['main']), file['path']
+            )
+            if (
+                os.path.exists(resource_path)
+                and resource_path != last_published_workfile_path
+            ):
                 shutil.copy(resource_path, resources_dir)

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -186,16 +186,19 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         # Keep source filepath for further path conformation
         self.data["source_filepath"] = last_published_workfile_path
 
+        # Get a make resources directory
         resources_dir = os.path.join(
             os.path.dirname(local_workfile_path), 'resources'
         )
         if not os.path.exists(resources_dir):
             os.mkdir(resources_dir)
 
+        # Copy resources to the local resources directory
         for file in workfile_representation['files']:
             resource_path = re.sub(
                 r"\{root\[main\]\}", str(anatomy.roots['main']), file['path']
             )
+            # Only copy if the resource file exists, and it's not the workfile
             if (
                 os.path.exists(resource_path)
                 and resource_path != last_published_workfile_path

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 from openpype.client.entities import (
@@ -184,3 +185,16 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         self.data["last_workfile_path"] = local_workfile_path
         # Keep source filepath for further path conformation
         self.data["source_filepath"] = last_published_workfile_path
+
+        resources_dir = os.path.join(local_workfile_dir, 'resources')
+        if not os.path.exists(resource_dir):
+            print(f"making dir {resources_dir}")
+            os.mkdir(resources_dir)
+
+        for file in workfile_representation['files']:
+            resource_path = re.sub(r"\{root\[main\]\}", str(anatomy.roots['main']), file['path'])
+            if os.path.exists(resource_path):
+                print(f"copying resource {resource_path}")
+                shutil.copy(resource_path, resources_dir)
+            else:
+                print(f"resource doesn't exist {resource_path}")

--- a/openpype/pipeline/publish/lib.py
+++ b/openpype/pipeline/publish/lib.py
@@ -7,6 +7,7 @@ import tempfile
 import xml.etree.ElementTree
 
 import six
+import pyblish.util
 import pyblish.plugin
 import pyblish.api
 


### PR DESCRIPTION
## Description
Copy resources from main site to local workfile resources folder.
Marked as draft since I was not able to perform sufficient testing due to unrelated issues.

## Testing notes
- Download a workfile that is not present locally (i.e. do a 'fab_old').
- If any resource is used in this workfile, they should be copied into the local `resources` folder.