### PR TITLE
Fix : transfer_stack skip readonly properties

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -329,8 +329,8 @@ def transfer_stack(
                 a
                 for a in dir(stack_datablock)
                 if not a.startswith("_")
-                and a
-                not in {
+                and stack_datablock.is_property_readonly(a)
+                and a not in {
                     "type",
                     "error_location",
                     "rna_type",

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -329,16 +329,8 @@ def transfer_stack(
                 a
                 for a in dir(stack_datablock)
                 if not a.startswith("_")
+                and a != "bl_rna"
                 and not stack_datablock.is_property_readonly(a)
-                and a not in {
-                    "type",
-                    "error_location",
-                    "rna_type",
-                    "error_rotation",
-                    "bl_rna",
-                    "is_valid",
-                    "is_override_data",
-                }
             }
             for attr in attributes:
                 setattr(target_data, attr, getattr(stack_datablock, attr))

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -329,7 +329,7 @@ def transfer_stack(
                 a
                 for a in dir(stack_datablock)
                 if not a.startswith("_")
-                and stack_datablock.is_property_readonly(a)
+                and not stack_datablock.is_property_readonly(a)
                 and a not in {
                     "type",
                     "error_location",


### PR DESCRIPTION
## Changelog Description
- transfer_stack check readonly properties and skip them.
