### PR TITLE
Fix: Orphan objects linked to scene

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -357,6 +357,7 @@ def make_paths_absolute(source_filepath: Path = None):
         bpy.ops.file.make_paths_absolute()
         return
 
+    remapped_paths = []
     for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
             if datablock and datablock.filepath.startswith("//"):
@@ -368,10 +369,13 @@ def make_paths_absolute(source_filepath: Path = None):
                         )
                     ).resolve()
                 )
+                remapped_paths.append(datablock.filepath)
         except (RuntimeError, ReferenceError, OSError) as e:
             print(e)
 
     bpy.ops.file.make_paths_absolute()
+
+    return remapped_paths
 
 
 def get_root_datablocks(
@@ -399,3 +403,20 @@ def get_root_datablocks(
         if (types is None or isinstance(d, tuple(types)))
         and not users & set(datablocks)
     }
+
+
+def get_all_datablocks():
+    """Get all datablocks from the current blend file.
+
+    Returns:
+        Set[bpy.types.ID]: All datablocks
+    """
+    all_datablocks = set()
+    for bl_type in dir(bpy.data):
+        if not bl_type.startswith("_"):
+            datacol = getattr(bpy.data, bl_type)
+            if isinstance(datacol, bpy.types.bpy_prop_collection) and len(
+                bl_type
+            ):
+                all_datablocks.update(getattr(bpy.data, bl_type))
+    return all_datablocks

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -357,7 +357,6 @@ def make_paths_absolute(source_filepath: Path = None):
         bpy.ops.file.make_paths_absolute()
         return
 
-    remapped_paths = []
     for datablock in list(bpy.data.libraries) + list(bpy.data.images):
         try:
             if datablock and datablock.filepath.startswith("//"):
@@ -369,13 +368,10 @@ def make_paths_absolute(source_filepath: Path = None):
                         )
                     ).resolve()
                 )
-                remapped_paths.append(datablock.filepath)
         except (RuntimeError, ReferenceError, OSError) as e:
             print(e)
 
     bpy.ops.file.make_paths_absolute()
-
-    return remapped_paths
 
 
 def get_root_datablocks(


### PR DESCRIPTION
## Changelog Description
Orphan objects were linked to scene, made datablocks filtering more accurate.

## Testing notes:
1. Regular loading
