### PR TITLE
Save and revert only if there areremapped datablocks from make_paths_absolute

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -354,10 +354,9 @@ def make_paths_absolute(source_filepath: Path = None):
         if not isinstance(data_collection, bpy.types.bpy_prop_collection):
             continue
         for datablock in data_collection.values():
-            if not hasattr(datablock, "filepath"):
-                break
             if (
-                not datablock.is_property_readonly("filepath")
+                hasattr(datablock, "filepath")
+                and not datablock.is_property_readonly("filepath")
                 and isinstance(datablock.filepath, str)
                 and datablock.filepath.startswith("//")
             ):
@@ -376,8 +375,8 @@ def make_paths_absolute(source_filepath: Path = None):
                 )
             except (RuntimeError, ReferenceError, OSError) as err:
                 print(err)
-    else:
-        bpy.ops.file.make_paths_absolute()
+
+    bpy.ops.file.make_paths_absolute()
 
     return {
         datablock

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -343,27 +343,47 @@ def make_paths_absolute(source_filepath: Path = None):
         source_filepath (Path, optional): Filepath to remap paths from,
             in case file copy has been executed without paths remapping.
             Defaults to None.
-    """
-    # In case no source filepath try naive system
-    if not source_filepath:
-        bpy.ops.file.make_paths_absolute()
-        return
 
-    for datablock in list(bpy.data.libraries) + list(bpy.data.images):
-        try:
-            if datablock and datablock.filepath.startswith("//"):
+    Returns:
+        Set[bpy.types.ID]: Remapped datablocks.
+    """
+
+    relative_datablocks = set()
+    for data_name in dir(bpy.data):
+        data_collection = getattr(bpy.data, data_name)
+        if not isinstance(data_collection, bpy.types.bpy_prop_collection):
+            continue
+        for datablock in data_collection.values():
+            if not hasattr(datablock, "filepath"):
+                break
+            if (
+                not datablock.is_property_readonly("filepath")
+                and isinstance(datablock.filepath, str)
+                and datablock.filepath.startswith("//")
+            ):
+                relative_datablocks.add((datablock, datablock.filepath))
+
+    if source_filepath:
+        for datablock, filepath in relative_datablocks:
+            try:
                 datablock.filepath = str(
                     Path(
                         bpy.path.abspath(
-                            datablock.filepath,
+                            filepath,
                             start=source_filepath.parent,
                         )
                     ).resolve()
                 )
-        except (RuntimeError, ReferenceError, OSError) as e:
-            print(e)
+            except (RuntimeError, ReferenceError, OSError) as err:
+                print(err)
+    else:
+        bpy.ops.file.make_paths_absolute()
 
-    bpy.ops.file.make_paths_absolute()
+    return {
+        datablock
+        for datablock, filepath in relative_datablocks
+        if datablock.filepath != filepath
+    }
 
 
 def get_root_datablocks(

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         nargs="?",
         help="source filepath",
     )
-    args = parser.parse_args(sys.argv[sys.argv.index("--") + 1:])
+    args = parser.parse_known_args(sys.argv[sys.argv.index("--") + 1:])
 
     if args.source_filepath.is_file():
         remapped_datablocks = make_paths_absolute(args.source_filepath)

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -25,11 +25,11 @@ if __name__ == "__main__":
         nargs="?",
         help="source filepath",
     )
-    args = parser.parse_args(sys.argv[sys.argv.index("--") + 1 :])
+    args = parser.parse_args(sys.argv[sys.argv.index("--") + 1:])
 
     if args.source_filepath.is_file():
-        make_paths_absolute(args.source_filepath)
+        remapped_datablocks = make_paths_absolute(args.source_filepath)
 
-    if bpy.data.filepath:
+    if bpy.data.filepath and remapped_datablocks:
         bpy.ops.wm.save_mainfile()
         bpy.ops.wm.revert_mainfile()

--- a/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_absolute.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         nargs="?",
         help="source filepath",
     )
-    args = parser.parse_known_args(sys.argv[sys.argv.index("--") + 1:])
+    args = parser.parse_known_args(sys.argv[sys.argv.index("--") + 1:])[0]
 
     if args.source_filepath.is_file():
         remapped_datablocks = make_paths_absolute(args.source_filepath)


### PR DESCRIPTION
## Changelog Description
- `make_paths_absolute` from `openpype.hosts.blender.api.utils` return remapped datablocks set
- `make_paths_absolute` script save and revert only if there are remapped datablocks