### PR TITLE
Refactor: Update/Switch reliable name matching, and few changes

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -703,7 +703,9 @@ class AssetLoader(Loader):
         ):
             for bl_type in self.bl_types:
                 data_collection_name = BL_TYPE_DATAPATH.get(bl_type)
-                loaded_datablocks = list(getattr(data_from, data_collection_name))
+                loaded_datablocks = list(
+                    getattr(data_from, data_collection_name)
+                )
                 setattr(
                     data_to,
                     data_collection_name,
@@ -711,18 +713,19 @@ class AssetLoader(Loader):
                 )
 
                 # Keep collection with datablocks
-                loaded_data_collections.append((data_collection_name, loaded_datablocks))
-
+                loaded_data_collections.append(
+                    (data_collection_name, loaded_datablocks)
+                )
 
                 # Keep loaded datablocks names
                 loaded_names.extend([str(l) for l in loaded_datablocks])
-        
-        # Assign original datablocks names to avoid name conflicts
+
         datablocks = set()
         i = 0
         for collection_name, loaded_datablocks in loaded_data_collections:
+            # Assign original datablocks names to avoid name conflicts
             for datablock in loaded_datablocks:
-                datablock["original_name"] = loaded_names[i]
+                datablock["source_name"] = loaded_names[i]
                 i += 1
 
             # Get datablocks
@@ -735,16 +738,17 @@ class AssetLoader(Loader):
             ]
             datacol.foreach_set("use_fake_user", seq)
 
-        # Get datablocks to override, which have
-        # no user in the loaded datablocks (orphan at this point)
-        datablocks_to_override = {
-            d
-            for d, users in bpy.data.user_map(subset=datablocks).items()
-            if not users & set(datablocks)
-        }
-
         # Override datablocks if needed
         if link and do_override:
+            # Get datablocks to override, only outliner datablocks which have
+            # no user in the loaded datablocks (orphan at this point)
+            datablocks_to_override = {
+                d
+                for d, users in bpy.data.user_map(subset=datablocks).items()
+                if not users & set(datablocks)
+                and isinstance(d, tuple(BL_OUTLINER_TYPES))
+            }
+
             override_datablocks = set()
             for d in datablocks_to_override:
                 # Override datablock and its children
@@ -1129,6 +1133,27 @@ class AssetLoader(Loader):
         """
         load_func = self.get_load_function()
 
+        # Keep current datablocks
+        old_datablocks = container.get_datablocks(only_local=False)
+
+        # Rename old datablocks
+        for old_datablock in old_datablocks:
+            if not old_datablock.library:
+                old_datablock.name += ".old"
+
+            # Restore original name for linked datablocks
+            if (
+                old_datablock.override_library
+                and old_datablock.override_library.reference
+            ):
+                old_datablock[
+                    "source_name"
+                ] = old_datablock.override_library.reference.name
+            elif old_datablock.library or not old_datablock.get("source_name"):
+                old_datablock["source_name"] = old_datablock.name
+
+            old_datablock.use_fake_user = False
+
         # Unlink from parent collection if existing
         parent_collections = {}
         for outliner_datablock in container.get_root_outliner_datablocks():
@@ -1137,18 +1162,9 @@ class AssetLoader(Loader):
 
                 # Store parent collection by name
                 parent_collections.setdefault(parent_collection, []).append(
-                    outliner_datablock.name
+                    outliner_datablock["source_name"]
                 )
 
-        # Keep current datablocks
-        old_datablocks = container.get_datablocks(only_local=False)
-
-        # Rename old datablocks
-        for old_datablock in old_datablocks:
-            # old_datablock["original_name"] = old_datablock.name
-            old_datablock.name += ".old"
-            old_datablock.use_fake_user = False
-        
         # Clear container datablocks
         container.datablock_refs.clear()
 
@@ -1158,31 +1174,27 @@ class AssetLoader(Loader):
             new_container_name,
             container=container,
         )
-        # print("tata", datablocks, self.bl_types)
 
         # Old datablocks remap
-        # for d in datablocks:
-        #     print(d)
-        #     d["original_name"]
         for old_datablock in old_datablocks:
-            # Find matching new datablock by name without .###
-            # but with same type and library or override library state
-            # print("toto", old_datablock)
-
+            # Find matching new datablock by name
             if new_datablock := next(
-                (
-                    d
-                    for d in datablocks
-                    if type(d) is type(old_datablock)
-                    and bool(old_datablock.library) == bool(d.library)
-                    and bool(old_datablock.override_library)
-                    == bool(d.override_library)
-                    and (old_datablock.get("original_name") and d.get("original_name") and old_datablock.get("original_name") == d["original_name"])
+                iter(
+                    sorted(
+                        (
+                            d
+                            for d in datablocks
+                            if type(d) is type(old_datablock)
+                            and old_datablock.get("source_name")
+                            == d.get("source_name")
+                        ),
+                        key=lambda d: d.name_full,
+                        # Library datablocks names are before override ones
+                        reverse=True,
+                    )
                 ),
                 None,
             ):
-                print("zaza", old_datablock, new_datablock)
-                # new_datablock.name = old_datablock["original_name"]
                 old_datablock.user_remap(new_datablock)
 
                 # Ensure action relink
@@ -1208,7 +1220,9 @@ class AssetLoader(Loader):
                 if hasattr(old_datablock, "pose") and old_datablock.pose:
                     for bone in old_datablock.pose.bones:
                         if new_datablock.pose:
-                            if new_bone := new_datablock.pose.bones.get(bone.name):
+                            if new_bone := new_datablock.pose.bones.get(
+                                bone.name
+                            ):
                                 transfer_stack(bone, "constraints", new_bone)
 
                 # Ensure drivers reassignation
@@ -1216,6 +1230,7 @@ class AssetLoader(Loader):
                     isinstance(old_datablock, bpy.types.Object)
                     and hasattr(new_datablock.data, "shape_keys")
                     and new_datablock.data.shape_keys
+                    and old_datablock.data
                 ):
                     for i, driver in enumerate(
                         new_datablock.data.shape_keys.animation_data.drivers
@@ -1239,9 +1254,17 @@ class AssetLoader(Loader):
             datablocks_to_change_parent = {
                 d
                 for d in datablocks
-                if d and not d.library and d.name in datablock_names
+                if d
+                and not d.library
+                and d.get("source_name") in datablock_names
             }
             link_to_collection(datablocks_to_change_parent, parent_collection)
+
+            # Need to unlink from scene collection to avoid duplicates
+            if parent_collection != bpy.context.scene.collection:
+                unlink_from_collection(
+                    datablocks_to_change_parent, bpy.context.scene.collection
+                )
 
         # Update override library operations from asset objects if available.
         for obj in container.get_datablocks(bpy.types.Object):

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1110,7 +1110,7 @@ class AssetLoader(Loader):
         )
 
         # Clear and purge useless datablocks
-        # orphans_purge()
+        orphans_purge()
 
         return container, datablocks
 
@@ -1338,7 +1338,7 @@ class AssetLoader(Loader):
         )
 
         # Clear and purge useless datablocks
-        # orphans_purge()
+        orphans_purge()
 
         return container, datablocks
 

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1177,7 +1177,7 @@ class AssetLoader(Loader):
 
         # Old datablocks remap
         for old_datablock in old_datablocks:
-            # Find matching new datablock by name
+            # Match new datablock by name
             if new_datablock := next(
                 iter(
                     sorted(

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -314,17 +314,19 @@ def transfer_stack(
     """
     src_col = getattr(source_datablock, stack_name)
     for stack_datablock in src_col:
+        if stack_datablock.is_override_data:
+            continue
+
         target_col = getattr(target_datablock, stack_name)
-        target_data = target_col.get(stack_datablock.name)
-        if not target_data:
+        target_stack_datablock = target_col.get(stack_datablock.name)
+        if not target_stack_datablock:
             if stack_name == "modifiers":
-                target_data = target_col.new(
+                target_stack_datablock = target_col.new(
                     stack_datablock.name, stack_datablock.type
                 )
             else:
-                target_data = target_col.new(stack_datablock.type)
-            
-            print("prout", source_datablock, target_datablock, target_col, target_data)
+                target_stack_datablock = target_col.new(stack_datablock.type)
+
             # Transfer attributes
             attributes = {
                 a
@@ -332,10 +334,15 @@ def transfer_stack(
                 if not a.startswith("_")
                 and a != "bl_rna"
                 and not callable(getattr(stack_datablock, a))
-                and not stack_datablock.is_property_readonly(a)
+                and hasattr(target_stack_datablock, a)
+                and not target_stack_datablock.is_property_readonly(a)
             }
             for attr in attributes:
-                setattr(target_data, attr, getattr(stack_datablock, attr))
+                setattr(
+                    target_stack_datablock,
+                    attr,
+                    getattr(stack_datablock, attr),
+                )
 
 
 def make_paths_absolute(source_filepath: Path = None):

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -323,7 +323,8 @@ def transfer_stack(
                 )
             else:
                 target_data = target_col.new(stack_datablock.type)
-
+            
+            print("prout", source_datablock, target_datablock, target_col, target_data)
             # Transfer attributes
             attributes = {
                 a


### PR DESCRIPTION
## Changelog Description
- Container's datablock replacement is still not perfectly reliable because of bad matching. The new system keeps the source name to match between old and new datablocks. This new system is much more reliable for stack transfer and handles modifiers/constraints transfer between linked/overriden and append, which is cool.
- Overriding datablocks hierarchy changed for only outliner ones. Because the override hierarchy is a shortcut to help artist, it is not necessary to be automatic on others data types. It still can be done through the UI if the artist needs it.
- Changed stack transfer condition test `is_property_readonly` on the target stack datablock, because we don't care if the source is readonly, only if the target attribute is (NB it may be readonly if linked).

## Testing notes:
1. Regular load, switch and update (tested with Lama in prod_test)
