### PR TITLE
Fix: empty collections are not overriden

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -765,7 +765,7 @@ class AssetLoader(Loader):
                         col
                         for col in d.children_recursive
                         # Don't add empty collections
-                        if col.children or col.all_objects
+                        if col.children and col.all_objects
                     )
                     if isinstance(d, bpy.types.Collection):
                         override_datablocks.update(d.all_objects)

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -761,7 +761,12 @@ class AssetLoader(Loader):
                 # Update datablocks because could have been renamed
                 override_datablocks.add(d)
                 if isinstance(d, tuple(BL_OUTLINER_TYPES)):
-                    override_datablocks.update(d.children_recursive)
+                    override_datablocks.update(
+                        col
+                        for col in d.children_recursive
+                        # Don't add empty collections
+                        if col.children or col.all_objects
+                    )
                     if isinstance(d, bpy.types.Collection):
                         override_datablocks.update(d.all_objects)
 


### PR DESCRIPTION
## Changelog Description
Empty collections are not overridden, but they were treated like they were.

## Testing notes:
1. Try to build e104_sh011 or e107_sh061
