### PR TITLE
Fix: replace no shape keys

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1238,6 +1238,7 @@ class AssetLoader(Loader):
                     and hasattr(new_datablock.data, "shape_keys")
                     and new_datablock.data.shape_keys
                     and old_datablock.data
+                    and old_datablock.data.shape_keys
                 ):
                     for i, driver in enumerate(
                         new_datablock.data.shape_keys.animation_data.drivers


### PR DESCRIPTION
## Changelog Description
If old datablock has no shape keys but new one does, it'd fail when asking `old_datablock.data.shape_keys`.

## Testing notes:
1. Open `e108_sh013` anim v009
2. Update Pirouette
