### PR TITLE
Fix: Override armature datablock

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -778,6 +778,10 @@ class AssetLoader(Loader):
                 # Set source_name
                 d["source_name"] = d.override_library.reference.name
 
+                # Override armature
+                if isinstance(d, bpy.types.Object) and d.type == "ARMATURE":
+                    d.data = d.data.override_create()
+
             # Add override datablocks to datablocks
             datablocks.update(override_datablocks)
 


### PR DESCRIPTION
## Changelog Description
Armature data are not overridden at loading, which leads to bone constraints loss.

## Testing notes:
1. Load any character's rig
2. Check armature is overridden
