### PR TITLE
Fix: Missing datablocks in container references

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -766,7 +766,7 @@ class AssetLoader(Loader):
                         col
                         for col in d.children_recursive
                         # Don't add empty collections
-                        if col.children and col.all_objects
+                        if col.children or col.all_objects
                     )
                     if isinstance(d, bpy.types.Collection):
                         override_datablocks.update(d.all_objects)


### PR DESCRIPTION
## Changelog Description
The condition was stupidly exigent.

## Testing notes:
1. Load a container
2. Switch to hero
