### PR TITLE
Fix: No any match considered as error

### DIFF
--- a/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
+++ b/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
@@ -109,7 +109,7 @@ class UnpauseSyncServer(pyblish.api.ContextPlugin):
                 result = future.result().decode()
 
                 # Iterate through matched errors
-                if errors_stack := re.finditer(match_tb, result):
+                if errors_stack := list(re.finditer(match_tb, result)):
                     # Match file path
                     blend_file = re.search(match_blend_file, result)
 


### PR DESCRIPTION
## Changelog Description
Even empty, a generator is considered as `True`, when casted as an empty `list` it'd be tested as `False`

## Testing notes:
1. Regular publish of prod_test Pingoo
