### PR TITLE
Fix: sound filepaths not remapped

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -345,6 +345,39 @@ def transfer_stack(
                 )
 
 
+def get_datablocks_with_filepath(
+    absolute=True, relative=True
+) -> Set[bpy.types.ID]:
+    """Get all datablocks with filepaths.
+
+    Args:
+        absolute (bool, optional): Get datablocks with absolute paths.
+            Defaults to True.
+        relative (bool, optional): Get datablocks with relative paths.
+            Defaults to True.
+
+    Returns:
+        Set[bpy.types.ID]: Datablocks with filepaths.
+    """
+    datablocks = set()
+    for data_name in dir(bpy.data):
+        data_collection = getattr(bpy.data, data_name)
+        if not isinstance(data_collection, bpy.types.bpy_prop_collection):
+            continue
+        for datablock in data_collection.values():
+            if (
+                datablock
+                and hasattr(datablock, "filepath")
+                and not datablock.is_property_readonly("filepath")
+                and not datablock.is_library_indirect
+            ):
+                if relative and datablock.filepath.startswith("//"):
+                    datablocks.add(datablock)
+                elif absolute:
+                    datablocks.add(datablock)
+    return datablocks
+
+
 def make_paths_absolute(source_filepath: Path = None):
     """Make all paths absolute for datablock in current blend file.
 
@@ -356,42 +389,26 @@ def make_paths_absolute(source_filepath: Path = None):
     Returns:
         Set[bpy.types.ID]: Remapped datablocks.
     """
-
-    relative_datablocks = set()
-    for data_name in dir(bpy.data):
-        data_collection = getattr(bpy.data, data_name)
-        if not isinstance(data_collection, bpy.types.bpy_prop_collection):
-            continue
-        for datablock in data_collection.values():
-            if (
-                hasattr(datablock, "filepath")
-                and not datablock.is_property_readonly("filepath")
-                and isinstance(datablock.filepath, str)
-                and datablock.filepath.startswith("//")
-            ):
-                relative_datablocks.add((datablock, datablock.filepath))
-
+    relative_datablocks = get_datablocks_with_filepath(absolute=False)
+    remapped_datablocks = set()
     if source_filepath:
-        for datablock, filepath in relative_datablocks:
+        for d in relative_datablocks:
             try:
-                datablock.filepath = str(
+                d.filepath = str(
                     Path(
                         bpy.path.abspath(
-                            filepath,
+                            d.filepath,
                             start=source_filepath.parent,
                         )
                     ).resolve()
                 )
+                remapped_datablocks.add(d)
             except (RuntimeError, ReferenceError, OSError) as err:
                 print(err)
 
     bpy.ops.file.make_paths_absolute()
 
-    return {
-        datablock
-        for datablock, filepath in relative_datablocks
-        if datablock.filepath != filepath
-    }
+    return remapped_datablocks
 
 
 def get_root_datablocks(

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -369,6 +369,7 @@ def get_datablocks_with_filepath(
                 datablock
                 and hasattr(datablock, "filepath")
                 and not datablock.is_property_readonly("filepath")
+                and not datablock.library
                 and not datablock.is_library_indirect
             ):
                 if relative and datablock.filepath.startswith("//"):

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -1,11 +1,12 @@
 """Make all paths relative."""
 
 from pathlib import Path
-from itertools import chain
 import sys
 import traceback
+
 import bpy
 
+from openpype.hosts.blender.api.utils import get_datablocks_with_filepath
 from openpype.lib.log import Logger
 
 if __name__ == "__main__":
@@ -15,17 +16,12 @@ if __name__ == "__main__":
     )
     errors = []
     # Resolve path from source filepath with the relative filepath
-    for datablock in chain(bpy.data.libraries, bpy.data.images):
+    for datablock in get_datablocks_with_filepath(relative=False):
         try:
-            if (
-                datablock
-                and not datablock.is_library_indirect
-                and not datablock.filepath.startswith("//")
-            ):
-                datablock.filepath = bpy.path.relpath(
-                    str(Path(datablock.filepath).resolve()),
-                    start=str(Path(bpy.data.filepath).parent.resolve()),
-                )
+            datablock.filepath = bpy.path.relpath(
+                str(Path(datablock.filepath).resolve()),
+                start=str(Path(bpy.data.filepath).parent.resolve()),
+            )
         except BaseException as e:
             errors.append(sys.exc_info())
 


### PR DESCRIPTION
## Changelog Description
Sound filepaths are not remapped as OP references but stick to the user's path.

- Made a common function `get_datablocks_with_filepath`.

## Testing notes:
1. Open empty workfile (ie `e666_sh001`)
2. Load an audio reference (ie `e104_sh029`)
3. Publish
4. Check published workfile has relative paths
5. Clear local workfile
6. Reopen with DL last wf, paths are remapped
