### PR TITLE
Fix: Update doesn't keep basic transforms on objects

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -1215,6 +1215,12 @@ class AssetLoader(Loader):
             ):
                 old_datablock.user_remap(new_datablock)
 
+                # Transfer transforms
+                if isinstance(old_datablock, bpy.types.Object):
+                    new_datablock.location = old_datablock.location
+                    new_datablock.rotation_euler = old_datablock.rotation_euler
+                    new_datablock.scale = old_datablock.scale
+
                 # Ensure action relink
                 if (
                     hasattr(old_datablock, "animation_data")


### PR DESCRIPTION
## Changelog Description
It may happen elements of a collection are moved only for the needs of a shot, without assigning any action to them. This is for keeping these small transform changes.

## Testing notes:
1. Merge this into the last OP release else you'll get errors when loading the setdress because of our `World` override
2. In prod test, load `Auntie_ESTAB_001_A_JOUR`
3. Move, scale, rotate the cube.
4. Change the version using the manage.
5. _NB: could also be tested in WoollyWoolly with any loaded env_
