### PR TITLE
Fix: Empty filepaths make remap fail

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -369,6 +369,7 @@ def get_datablocks_with_filepath(
                 datablock
                 and hasattr(datablock, "filepath")
                 and not datablock.is_property_readonly("filepath")
+                and not datablock.filepath == ""
                 and not datablock.library
                 and not datablock.is_library_indirect
             ):


### PR DESCRIPTION
## Changelog Description
Empty filepaths raises errors.

## Testing notes:
1. Load the prod test workfile you like
2. Create an empty text block in Blender's scripting
3. Publish workfile
