### PR TITLE
fix get_datablocks_with_filepath absolute

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -375,7 +375,7 @@ def get_datablocks_with_filepath(
             ):
                 if relative and datablock.filepath.startswith("//"):
                     datablocks.add(datablock)
-                elif absolute:
+                elif absolute and not datablock.filepath.startswith("//"):
                     datablocks.add(datablock)
     return datablocks
 


### PR DESCRIPTION
## Changelog Description
Before fix: 
- `get_datablocks_with_filepath(relative=False, absolute=True)` return relative path
