### PR TITLE
add: validator for setdress objects names

### DIFF
--- a/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
+++ b/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
@@ -1,0 +1,39 @@
+from typing import List
+
+import bpy
+import string
+
+import pyblish.api
+
+import openpype.hosts.blender.api.action
+from openpype.pipeline.publish import ValidateContentsOrder
+
+
+class ValidateSetdressObjectNames(pyblish.api.InstancePlugin):
+    """Validate that the objects names don't have special characters."""
+
+    order = ValidateContentsOrder
+    hosts = ["blender"]
+    families = ["setdress"]
+    label = "Validate SetDress Objects Name"
+    actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
+    optional = False
+
+    @staticmethod
+    def get_invalid(instance) -> List:
+        invalid = []
+
+        # Set of special characters except "_" which is used in naming
+        invalid_chars = set(string.punctuation.replace("_",""))
+        for obj in instance:
+            # any is faster than regex to get char in obj.name and return bool
+            if obj is not None and any(char in invalid_chars for char in obj.name):
+                invalid.append(obj)
+        return invalid
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError(
+                f"Objects found with special characters in their name: {invalid}"
+            )

--- a/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
+++ b/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
@@ -23,8 +23,9 @@ class ValidateSetdressObjectNames(pyblish.api.InstancePlugin):
     def get_invalid(instance) -> List:
         invalid = []
 
-        # Set of special characters except "_" which is used in naming
+        # Set of special characters except "_" and "." which is used in naming
         invalid_chars = set(string.punctuation.replace("_",""))
+        invalid_chars.remove(".")
         for obj in instance:
             # any is faster than regex to get char in obj.name and return bool
             if obj is not None and any(char in invalid_chars for char in obj.name):

--- a/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
+++ b/openpype/hosts/blender/plugins/publish/validate_setdress_object_names.py
@@ -9,7 +9,7 @@ import openpype.hosts.blender.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 
 
-class ValidateSetdressObjectNames(pyblish.api.InstancePlugin):
+class ValidateSetdressObjectNames(pyblish.api.Validator):
     """Validate that the objects names don't have special characters."""
 
     order = ValidateContentsOrder


### PR DESCRIPTION
## Changelog Description
Add a validator in the publish setdress. The validator check the objects names to raise an error when there is a special character in it's name.

## Testing notes:
1. Open a setdress scene in blender with OpenPype (ex: woollywoolly/Assets/Environement/ChampFleurs_038_A_JOUR --> Fabrication)
2. Open publish the OpenPype tab and wait for the collect step to end (you'll maybe have to relink libraries and clear OP containers with WW Util if the collect step raise an error)
3. Click on the debug button to execute the validate step
4. If there is an error on setdress objects names with a special character except "_" and "." the "Validate SetDress Objects Name" step should raise an error with the name of the object else no error is raised.
