### PR TITLE
Bugfix: get datablocks with filepath should skip indirect lib

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -369,12 +369,12 @@ def get_datablocks_with_filepath(
                 datablock
                 and hasattr(datablock, "filepath")
                 and not datablock.is_property_readonly("filepath")
-                and not datablock.filepath == ""
+                and datablock.filepath != ""
                 and not datablock.library
                 and not datablock.is_library_indirect
-                and (
-                    not isinstance(datablock, bpy.types.Library)
-                    or not datablock.parent
+                and not (
+                    isinstance(datablock, bpy.types.Library)
+                    and datablock.parent
                 )
             ):
                 if relative and datablock.filepath.startswith("//"):

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -372,6 +372,10 @@ def get_datablocks_with_filepath(
                 and not datablock.filepath == ""
                 and not datablock.library
                 and not datablock.is_library_indirect
+                and (
+                    not isinstance(datablock, bpy.types.Library)
+                    or not datablock.parent
+                )
             ):
                 if relative and datablock.filepath.startswith("//"):
                     datablocks.add(datablock)


### PR DESCRIPTION
## Changelog Description
Because attrs `is_library_indirect` and `library` is always `False` and `None` for `bpy.types.Library` we need to check if libraries have parent to know if is library indirect. But attr `parent` should be check only if datablock is `bpy.types.Library` because some datablock types have not parent attr (e.g. bpy.types.Sound).