### PR TITLE
Enhancement: make paths relative skip no file images

### DIFF
--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -17,6 +17,12 @@ if __name__ == "__main__":
     errors = []
     # Resolve path from source filepath with the relative filepath
     for datablock in get_datablocks_with_filepath(relative=False):
+        # skip render result, compositing and generated images
+        if (
+            isinstance(datablock, bpy.types.Images)
+            and datablock.source in ("GENERATED", "VIEWER")
+        ):
+            continue
         try:
             datablock.filepath = bpy.path.relpath(
                 str(Path(datablock.filepath).resolve()),

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         # skip render result, compositing and generated images
         if (
             isinstance(datablock, bpy.types.Images)
-            and datablock.source in ("GENERATED", "VIEWER")
+            and datablock.source in {"GENERATED", "VIEWER"}
         ):
             continue
         try:


### PR DESCRIPTION
## Changelog Description
- make_paths_relative process whilt publishing skip images that are not file source, because render result, compositing and generated images have output filepath, only input filepath should be remap.