### PR TITLE
add: validator setdress instances cam and review

### DIFF
--- a/openpype/hosts/blender/plugins/publish/validate_setdress_cam_instance.py
+++ b/openpype/hosts/blender/plugins/publish/validate_setdress_cam_instance.py
@@ -1,0 +1,49 @@
+from typing import List
+
+import bpy
+import string
+
+import pyblish.api
+
+import openpype.hosts.blender.api.action
+from openpype.pipeline.publish import ValidateContentsOrder
+
+
+class ValidateSetdressCamInstance(pyblish.api.Validator):
+    """Validate that cam and review instances points on the right collection."""
+
+    order = ValidateContentsOrder
+    hosts = ["blender"]
+    families = ["setdress"]
+    label = "Validate SetDress Cam Review Instances"
+    actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
+    optional = False
+
+    @staticmethod
+    def get_invalid(instance) -> List:
+        invalid = []
+
+        # Get all openpype instances
+        all_instances = bpy.context.scene.openpype_instances
+
+        for inst in all_instances:
+            # Check only cameraMain and reviewMain instances
+            if inst.name.find("cameraMain") != -1 or inst.name.find("reviewMain") != -1:
+                datablocks = None
+                datablocks = inst.get_datablocks()
+                # Check if the datablocks set is not empty
+                if len(list(datablocks)) > 0:
+                    for datablock in datablocks:
+                        # Check if the datablock is not a collection
+                        if type(datablock) is not bpy.types.Collection and inst.name not in invalid:
+                            invalid.append(inst.name)
+                else:
+                    invalid.append(inst.name)
+        return invalid
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError(
+                f"Instance(s) {invalid} is/are not pointing on a collection."
+            )

--- a/openpype/hosts/blender/plugins/publish/validate_setdress_cam_instance.py
+++ b/openpype/hosts/blender/plugins/publish/validate_setdress_cam_instance.py
@@ -9,13 +9,13 @@ import openpype.hosts.blender.api.action
 from openpype.pipeline.publish import ValidateContentsOrder
 
 
-class ValidateSetdressCamInstance(pyblish.api.Validator):
-    """Validate that cam and review instances points on the right collection."""
+class ValidateReviewCamInstance(pyblish.api.Validator):
+    """Validate that cam and review instances point to the right collection."""
 
     order = ValidateContentsOrder
     hosts = ["blender"]
-    families = ["setdress"]
-    label = "Validate SetDress Cam Review Instances"
+    families = ["review", "camera"]
+    label = "Validate Cam Review Instances"
     actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
     optional = False
 
@@ -23,27 +23,15 @@ class ValidateSetdressCamInstance(pyblish.api.Validator):
     def get_invalid(instance) -> List:
         invalid = []
 
-        # Get all openpype instances
-        all_instances = bpy.context.scene.openpype_instances
-
-        for inst in all_instances:
-            # Check only cameraMain and reviewMain instances
-            if inst.name.find("cameraMain") != -1 or inst.name.find("reviewMain") != -1:
-                datablocks = None
-                datablocks = inst.get_datablocks()
-                # Check if the datablocks set is not empty
-                if len(list(datablocks)) > 0:
-                    for datablock in datablocks:
-                        # Check if the datablock is not a collection
-                        if type(datablock) is not bpy.types.Collection and inst.name not in invalid:
-                            invalid.append(inst.name)
-                else:
-                    invalid.append(inst.name)
+        for obj in instance:
+            # Check if the object is not a collection
+            if not isinstance(obj, bpy.types.Collection) and instance not in invalid:
+                invalid.append(instance)
         return invalid
 
     def process(self, instance):
         invalid = self.get_invalid(instance)
         if invalid:
             raise RuntimeError(
-                f"Instance(s) {invalid} is/are not pointing on a collection."
+                f"Instance(s) {invalid} is/are not pointing to a collection."
             )


### PR DESCRIPTION
## Changelog Description
Add a validator to check if camMain and reviewMain instances are pointing on object(s)

## Testing notes:
1. Open a setDress asset in blender with OP launcher (ex:WoollyWooly/Assets/Environment/ChampFleurs_039_A_JOUR)
2. In the OpenPype menu, click on publish (you may have to relink libraries and clean OP containers with WW utils before)
3. Wait for the collect step in publish
4. Click on the test button to test only the validators
5. The "Validate SetDress Cam Review Instances" validator should raise an error with the instance(s)'s name(s) if the camMain or reviewMain instances are pointing on objects or if they are empty. No errors are raised if they are pointing on collections.
