### PR TITLE
Refactor: Openpype containers moved from scene to Window Manager

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -57,10 +57,10 @@ def create_container(
     """
     # Ensure container name
     name = ensure_unique_name(
-        name, bpy.context.scene.openpype_containers.keys()
+        name, bpy.context.window_manager.openpype_containers.keys()
     )
 
-    container = bpy.context.scene.openpype_containers.add()
+    container = bpy.context.window_manager.openpype_containers.add()
     container.name = name
 
     add_datablocks_to_container(datablocks, container)
@@ -112,7 +112,7 @@ def update_scene_containers() -> List[OpenpypeContainer]:
     Returns:
         List[OpenpypeContainer]: Created containers
     """
-    openpype_containers = bpy.context.scene.openpype_containers
+    openpype_containers = bpy.context.window_manager.openpype_containers
     scene_collection = bpy.context.scene.collection
 
     # Prepare datablocks to skip for containers auto creation
@@ -234,7 +234,7 @@ def update_scene_containers() -> List[OpenpypeContainer]:
         create_container(container_name, container_datablocks)
         # NOTE need to get it this way because memory could have changed
         # BUG: https://projects.blender.org/blender/blender/issues/105338
-        container = bpy.context.scene.openpype_containers[-1]
+        container = bpy.context.window_manager.openpype_containers[-1]
 
         # Keep objectName for update/switch
         container_metadata["objectName"] = container.name
@@ -248,7 +248,7 @@ def update_scene_containers() -> List[OpenpypeContainer]:
 
     # Clear containers when data has been deleted from the outliner
     for i, container in reversed(
-        list(enumerate(bpy.context.scene.openpype_containers))
+        list(enumerate(bpy.context.window_manager.openpype_containers))
     ):
         # In case all datablocks removed, remove container
         if not any(container.get_datablocks(only_local=False)):
@@ -269,7 +269,7 @@ def ls() -> Iterator:
     # Parse containers
     return [
         parse_container(container)
-        for container in bpy.context.scene.openpype_containers
+        for container in bpy.context.window_manager.openpype_containers
     ]
 
 

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -627,7 +627,7 @@ class SCENE_OT_RemoveOpenpypeInstance(
         # Get creator class
         Creator = get_legacy_creator_by_name(self.creator_name)
 
-        # NOTE Shunting legacy_create because of useless overhead 
+        # NOTE Shunting legacy_create because of useless overhead
         # and deprecated design.
         # Will see if compatible with new creator when implemented for Blender
         avalon_prop = op_instance["avalon"]
@@ -1066,7 +1066,7 @@ class SCENE_OT_MakeContainerPublishable(bpy.types.Operator):
         if matched_container := next(
             (
                 container
-                for container in context.scene.openpype_containers
+                for container in context.window_manager.openpype_containers
                 if context.collection
                 in container.get_root_outliner_datablocks()
             ),
@@ -1090,7 +1090,7 @@ class SCENE_OT_MakeContainerPublishable(bpy.types.Operator):
             return {"CANCELLED"}
 
         # Recover required data
-        openpype_containers = context.scene.openpype_containers
+        openpype_containers = context.window_manager.openpype_containers
         container = openpype_containers.get(self.container_name)
         avalon_data = dict(container["avalon"])
 
@@ -1148,7 +1148,7 @@ def expose_container_content(container_name: str) -> List[bpy.types.ID]:
         List[bpy.types.ID]: List of root outliner datablocks.
     """
     # Recover required data
-    openpype_containers = bpy.context.scene.openpype_containers
+    openpype_containers = bpy.context.window_manager.openpype_containers
     container = openpype_containers.get(container_name)
 
     # Remove old container
@@ -1211,7 +1211,7 @@ class SCENE_OT_ExposeContainerContent(bpy.types.Operator):
         if matched_container := next(
             (
                 container
-                for container in context.scene.openpype_containers
+                for container in context.window_manager.openpype_containers
                 if context.collection
                 in container.get_root_outliner_datablocks()
             ),

--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -156,7 +156,7 @@ def remove_container(
         bpy.data.libraries.remove(container.library)
 
     # Delete container
-    openpype_containers = bpy.context.scene.openpype_containers
+    openpype_containers = bpy.context.window_manager.openpype_containers
     openpype_containers.remove(openpype_containers.find(container.name))
 
     # Orphan purge
@@ -666,7 +666,7 @@ class AssetLoader(Loader):
         Returns:
             Optional[OpenpypeContainer]: Scene container. Can be None.
         """
-        return bpy.context.scene.openpype_containers.get(
+        return bpy.context.window_manager.openpype_containers.get(
             container["objectName"]
         )
 
@@ -1358,7 +1358,7 @@ class AssetLoader(Loader):
             if container.name.startswith(container_basename)
             else ensure_unique_name(
                 container_basename,
-                bpy.context.scene.openpype_containers.keys(),
+                bpy.context.window_manager.openpype_containers.keys(),
             ),
         )
 

--- a/openpype/hosts/blender/api/properties.py
+++ b/openpype/hosts/blender/api/properties.py
@@ -179,7 +179,7 @@ def register():
     bpy.types.Scene.openpype_instance_active_index = bpy.props.IntProperty(
         name="OpenPype Instance Active Index", options={"HIDDEN"}
     )
-    bpy.types.Scene.openpype_containers = bpy.props.CollectionProperty(
+    bpy.types.WindowManager.openpype_containers = bpy.props.CollectionProperty(
         name="OpenPype Containers", type=OpenpypeContainer, options={"HIDDEN"}
     )
 
@@ -191,4 +191,4 @@ def unregister():
     del bpy.types.Scene.openpype_instances
     del bpy.types.Scene.openpype_instance_active_index
 
-    del bpy.types.Scene.openpype_containers
+    del bpy.types.window_manager.openpype_containers

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -290,7 +290,7 @@ def assign_loader_to_datablocks(datablocks: List[bpy.types.ID]):
         datablock[AVALON_PROPERTY]["loader"] = loader_name or ""
 
         # Set to related container
-        container = bpy.context.scene.openpype_containers.get(datablock.name)
+        container = bpy.context.window_manager.openpype_containers.get(datablock.name)
         if container and container.get(AVALON_PROPERTY):
             container[AVALON_PROPERTY]["loader"] = loader_name
 


### PR DESCRIPTION
## Changelog Description
Storing containers into `context.scene` makes Blender evaluate them during render building and creates a big RAM overload. This refactor moves them to the `context.window_manager` to avoid this behaviour.

## Testing notes:
1. Checkout to the latest branch release
2. Merge the current branch
3. Merge the https://github.com/Tilix4/OpenPype/pull/58
4. Checkout your addon to https://gitlab.com/NORMAAL/openpype-studio-addon/-/merge_requests/68
5. Open any workfile and start a render, the RAM should be much much less
