### PR TITLE
Fix: Packed files are remaped

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -372,6 +372,10 @@ def get_datablocks_with_filepath(
                 and datablock.filepath != ""
                 and not datablock.library
                 and not datablock.is_library_indirect
+                and not (
+                    isinstance(datablock, bpy.types.Image)
+                    and datablock.packed_file
+                )
             ):
                 if relative and datablock.filepath.startswith("//"):
                     datablocks.add(datablock)


### PR DESCRIPTION
## Changelog Description
Packed files are remapped when they shouldn't.

## Testing notes:
1. Pack a file from a different disk than your `main`
2. Publish
