### PR TITLE
get_datablocks_with_filepath accept indirect lib

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -372,10 +372,6 @@ def get_datablocks_with_filepath(
                 and datablock.filepath != ""
                 and not datablock.library
                 and not datablock.is_library_indirect
-                and not (
-                    isinstance(datablock, bpy.types.Library)
-                    and datablock.parent
-                )
             ):
                 if relative and datablock.filepath.startswith("//"):
                     datablocks.add(datablock)


### PR DESCRIPTION
## Changelog Description
Because indirect lib should be mapped with same path of this parent lib.
