### PR TITLE
Refactor: Reset scene containers

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -158,7 +158,7 @@ def get_user_links(
         }
         not_linked = {d for d in not_linked if isinstance(d, types)}
 
-    return users_links, not_linked
+    return users_links, all_not_linked
 
 
 def _recursive_collect_user_links(
@@ -267,7 +267,7 @@ def update_scene_containers():
         container[AVALON_PROPERTY] = container_metadata
         container.library = (
             entity.override_library.reference.library
-            if entity.override_library
+            if entity.override_library and entity.override_library.reference
             else entity.library
         )
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -168,7 +168,7 @@ def _recursive_collect_user_links(
     exclude: set,
     user_map: dict,
 ):
-    """Recursive function to collect all datablocks linked to the user datablock.
+    """Collect recursively all datablocks linked to the user datablock.
 
     Args:
         datablock (bpy.types.ID): Datablock currently tested.

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -199,7 +199,7 @@ def _recursive_collect_user_links(
             exclude.add(datablock)
 
 
-def reset_scene_containers():
+def update_scene_containers():
     """Reset containers in scene."""
     scene_collection = bpy.context.scene.collection
 
@@ -279,7 +279,7 @@ def ls() -> Iterator:
     disk, it lists assets already loaded in Blender; once loaded they are
     called containers.
     """
-    reset_scene_containers()
+    update_scene_containers()
 
     # Parse containers
     return [


### PR DESCRIPTION
## Changelog Description
This refactors the way container datablocks are collected. As since we don't store containers into `scene`, the list has to be recreated each time we open the `Manage`. This algorithm is faster and more reliable.

## Testing notes:
1. Merge to last staging (may have few conflicts, easy to resolve)
1. Open any scene (tested on `e102_sh011` among others)
2. Open the manage
3. Try to switch or remove Willy (or any other rig/props/setdress)
