### PR TITLE
Fix: Infinite loop on update_scene_containers

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -202,8 +202,6 @@ def _recursive_collect_user_links(
     # cannot process twice the same datablock
     if datablock in not_linked:
         return
-    else:
-        not_linked.add(datablock)
 
     for user in user_map.get(datablock, []):
         # Check not self reference to avoid infinite loop
@@ -216,6 +214,7 @@ def _recursive_collect_user_links(
         elif user == target_user_datablock:
             links.add(datablock)
         elif user not in links | not_linked:
+            not_linked.add(datablock)
             _recursive_collect_user_links(
                 user, target_user_datablock, links, not_linked, user_map
             )
@@ -223,7 +222,6 @@ def _recursive_collect_user_links(
         # Add datablock to links if user is linked to target datablock
         if user in links:
             links.add(datablock)
-            not_linked.remove(datablock)
             break
 
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -182,7 +182,7 @@ def _recursive_collect_user_links(
     datablock: bpy.types.ID,
     target_user_datablock: bpy.types.ID,
     links: set,
-    exclude: set,
+    not_linked: set,
     user_map: dict,
 ):
     """Collect recursively all datablocks linked to the user datablock.
@@ -194,9 +194,17 @@ def _recursive_collect_user_links(
         datablock (bpy.types.ID): Datablock currently tested.
         target_user_datablock (bpy.types.ID): Datablock to get links from.
         links (set): Set of datablocks linked to the user datablock.
-        exclude (set): Set of datablocks to exclude from search.
+        not_linked (set): Set of datablocks processed but not linked to the
+            user datablock.
         user_map (dict): User map of all datablocks in blend file.
     """
+    # Meant to avoid infinite loop, because of circular references
+    # cannot process twice the same datablock
+    if datablock in not_linked:
+        return
+    else:
+        not_linked.add(datablock)
+
     for user in user_map.get(datablock, []):
         # Check not self reference to avoid infinite loop
         if (
@@ -207,16 +215,16 @@ def _recursive_collect_user_links(
             continue
         elif user == target_user_datablock:
             links.add(datablock)
-        elif user not in links | exclude:
+        elif user not in links | not_linked:
             _recursive_collect_user_links(
-                user, target_user_datablock, links, exclude, user_map
+                user, target_user_datablock, links, not_linked, user_map
             )
 
         # Add datablock to links if user is linked to target datablock
         if user in links:
             links.add(datablock)
-        else:
-            exclude.add(datablock)
+            not_linked.remove(datablock)
+            break
 
 
 def update_scene_containers():


### PR DESCRIPTION
## Changelog Description
Had to control datablocks are not processed twice, because they can reference ones that are deeper in the hierarchy, which starts the loop from an higher level, infinitely...

## Testing notes:
1. Tested on `e111_sh051`
2. Open Manage
3. Other containers management operations...
