### PR TITLE
Fix: transfer bone constraints

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -352,9 +352,6 @@ def transfer_stack(
     """
     src_col = getattr(source_datablock, stack_name)
     for stack_datablock in src_col:
-        if stack_datablock.is_override_data:
-            continue
-
         target_col = getattr(target_datablock, stack_name)
         target_stack_datablock = target_col.get(stack_datablock.name)
         if not target_stack_datablock:


### PR DESCRIPTION
## Changelog Description
Override data test is a bit strange, it was made for optim but it is safer to transfer in all cases.

## Testing notes:
1. Build animation of `e111_sh038`
2. Check Snowlly still swings with the medallion
