### PR TITLE
Bugfix: Resource paths mapped to `main` site instead of `work` site.

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -438,7 +438,6 @@ def make_paths_absolute(source_filepath: Path = None):
     relative_datablocks = get_datablocks_with_filepath(absolute=False)
     remapped_datablocks = set()
     if source_filepath:
-        # Get last workfile representation
         workfile_repre = get_last_workfile_representation(
             get_current_project_name(),
             get_current_asset_name(),

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -17,6 +17,7 @@ from openpype.pipeline.load.plugins import (
     discover_loader_plugins,
 )
 from openpype.pipeline.load.utils import loaders_from_repre_context
+from openpype.pipeline.workfile import get_last_workfile_representation
 
 
 # Key for metadata dict
@@ -438,21 +439,10 @@ def make_paths_absolute(source_filepath: Path = None):
     remapped_datablocks = set()
     if source_filepath:
         # Get last workfile representation
-        workfile_repre = max(
-            filter(
-                lambda r: r["context"].get("version") is not None,
-                list(
-                    get_representations(
-                        get_current_project_name(),
-                        context_filters={
-                            "asset": get_current_asset_name(),
-                            "family": "workfile",
-                            "task": {"name": get_current_task_name()},
-                        },
-                    )
-                )
-            ),
-            key=lambda r: r["context"]["version"],
+        workfile_repre = get_last_workfile_representation(
+            get_current_project_name(),
+            get_current_asset_name(),
+            get_current_task_name(),
         )
 
         for d in relative_datablocks:

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -437,27 +437,33 @@ def make_paths_absolute(source_filepath: Path = None):
     relative_datablocks = get_datablocks_with_filepath(absolute=False)
     remapped_datablocks = set()
     if source_filepath:
+        # Get last workfile representation
         workfile_repre = max(
             filter(
                 lambda r: r["context"].get("version") is not None,
-                list(get_representations(
-                    get_current_project_name(),
-                    context_filters={
-                        "asset": get_current_asset_name(),
-                        "family": "workfile",
-                        "task": {"name": get_current_task_name()},
-                    },
-                ))
+                list(
+                    get_representations(
+                        get_current_project_name(),
+                        context_filters={
+                            "asset": get_current_asset_name(),
+                            "family": "workfile",
+                            "task": {"name": get_current_task_name()},
+                        },
+                    )
+                )
             ),
             key=lambda r: r["context"]["version"],
         )
 
         for d in relative_datablocks:
             try:
+                # Check if datablock is a resource file
                 for file in workfile_repre.get("files"):
                     if Path(file.get("path", "")).name == Path(
                         d.filepath
                     ).name:
+                        # Make resource datablock path absolute,
+                        # starting from workdir
                         d.filepath = str(
                             Path(
                                 bpy.path.abspath(
@@ -467,6 +473,7 @@ def make_paths_absolute(source_filepath: Path = None):
                         )
                         break
                 else:
+                    # Make datablock path absolute, starting from source path
                     d.filepath = str(
                         Path(
                             bpy.path.abspath(

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -24,7 +24,6 @@ if __name__ == "__main__":
     )
     errors = []
 
-    # Get last workfile representation
     workfile_repre = get_last_workfile_representation(
         get_current_project_name(),
         get_current_asset_name(),

--- a/openpype/hosts/blender/utility_scripts/make_paths_relative.py
+++ b/openpype/hosts/blender/utility_scripts/make_paths_relative.py
@@ -14,6 +14,7 @@ from openpype.pipeline.context_tools import (
     get_current_task_name,
     get_workdir_from_session,
 )
+from openpype.pipeline.workfile import get_last_workfile_representation
 from openpype.lib.log import Logger
 
 if __name__ == "__main__":
@@ -24,22 +25,12 @@ if __name__ == "__main__":
     errors = []
 
     # Get last workfile representation
-    workfile_repre = max(
-        filter(
-            lambda r: r["context"].get("version") is not None,
-            list(
-                get_representations(
-                    get_current_project_name(),
-                    context_filters={
-                        "asset": get_current_asset_name(),
-                        "family": "workfile",
-                        "task": {"name": get_current_task_name()},
-                    },
-                )
-            ),
-        ),
-        key=lambda r: r["context"]["version"],
+    workfile_repre = get_last_workfile_representation(
+        get_current_project_name(),
+        get_current_asset_name(),
+        get_current_task_name(),
     )
+
     workdir = get_workdir_from_session()
 
     # Resolve path from source filepath with the relative filepath

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -14,6 +14,7 @@ from openpype.modules.sync_server.sync_server import (
 from openpype.pipeline.template_data import get_template_data
 from openpype.pipeline.workfile.path_resolving import (
     get_workfile_template_key,
+    get_last_workfile_representation,
 )
 from openpype.settings.lib import get_project_settings
 
@@ -113,31 +114,10 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         asset_doc = self.data.get("asset_doc")
         anatomy = self.data.get("anatomy")
 
-        context_filters = {
-            "asset": asset_name,
-            "family": "workfile",
-            "task": {"name": task_name, "type": task_type}
-        }
-
-        workfile_representations = list(get_representations(
+        workfile_representation = get_last_workfile_representation(
             project_name,
-            context_filters=context_filters
-        ))
-
-        if not workfile_representations:
-            self.log.debug(
-                'No published workfile for task "{}" and host "{}".'.format(
-                    task_name, host_name
-                )
-            )
-            return
-
-        filtered_repres = filter(
-            lambda r: r["context"].get("version") is not None,
-            workfile_representations
-        )
-        workfile_representation = max(
-            filtered_repres, key=lambda r: r["context"]["version"]
+            asset_name,
+            task_name,
         )
 
         # Copy file and substitute path

--- a/openpype/pipeline/workfile/__init__.py
+++ b/openpype/pipeline/workfile/__init__.py
@@ -6,6 +6,7 @@ from .path_resolving import (
 
     get_last_workfile_with_version,
     get_last_workfile,
+    get_last_workfile_representation,
 
     get_custom_workfile_template,
     get_custom_workfile_template_by_string_context,
@@ -24,6 +25,7 @@ __all__ = (
 
     "get_last_workfile_with_version",
     "get_last_workfile",
+    "get_last_workfile_representation",
 
     "get_custom_workfile_template",
     "get_custom_workfile_template_by_string_context",

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -3,7 +3,11 @@ import re
 import copy
 import platform
 
-from openpype.client import get_project, get_asset_by_name
+from openpype.client import (
+    get_project,
+    get_asset_by_name,
+    get_representations,
+)
 from openpype.settings import get_project_settings
 from openpype.lib import (
     filter_profiles,
@@ -528,3 +532,21 @@ def create_workdir_extra_folders(
         fullpath = os.path.join(workdir, subfolder)
         if not os.path.exists(fullpath):
             os.makedirs(fullpath)
+
+def get_last_workfile_representation(project_name, asset_name, task_name):
+    return max(
+        filter(
+            lambda r: r["context"].get("version") is not None,
+            list(
+                get_representations(
+                    project_name,
+                    context_filters={
+                        "asset": asset_name,
+                        "family": "workfile",
+                        "task": {"name": task_name},
+                    },
+                )
+            ),
+        ),
+        key=lambda r: r["context"]["version"],
+    )


### PR DESCRIPTION
## Changelog Description
Fix resource files being mapped to main site instead of work site.

## Testing notes
- Open any workfile with resource files.
- Publish it.
- Use the fab_old technique (or force download last workfile if available).
- Check resource paths, they should be mapped to the `resources` folder in the local workfile folder.
- Check all link paths, they should be unaffected by these changes (pointing to `main` site path).