### PR TITLE
Bugfix: Backport `get_last_workefile_representation` changes

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -124,7 +124,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug(
                 'No published workfile for task "{}" and host "{}".'.format(
                     task_name, host_name
-                )   
+                )
             )
             return
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -118,7 +118,11 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             project_name,
             asset_name,
             task_name,
+            asset_doc=asset_doc,
         )
+        if not workfile_representation:
+            self.log.debug("No workfile representation found.")
+            return
 
         # Copy file and substitute path
         last_published_workfile_path = download_last_published_workfile(

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -121,7 +121,11 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             asset_doc=asset_doc,
         )
         if not workfile_representation:
-            self.log.debug("No workfile representation found.")
+            self.log.debug(
+                'No published workfile for task "{}" and host "{}".'.format(
+                    task_name, host_name
+                )   
+            )
             return
 
         # Copy file and substitute path

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -567,7 +567,7 @@ def get_last_workfile_representation(
         project_name,
         get_subset_name(
             "workfile",
-            "",
+            "main",
             task_name,
             asset_doc,
             project_name=project_name,

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -533,7 +533,22 @@ def create_workdir_extra_folders(
         if not os.path.exists(fullpath):
             os.makedirs(fullpath)
 
-def get_last_workfile_representation(project_name, asset_name, task_name):
+
+def get_last_workfile_representation(
+    project_name: str,
+    asset_name: str,
+    task_name: str,
+) -> dict:
+    """Get last published workfile representation.
+
+    Args:
+        project_name(str): Project name.
+        asset_name(str): Asset/Shot name.
+        task_name(str): Task name.
+
+    Returns:
+        dict: Last workfile representation.
+    """
     return max(
         filter(
             lambda r: r["context"].get("version") is not None,

--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -2,12 +2,15 @@ import os
 import re
 import copy
 import platform
+from typing import Iterable
 
 from openpype.client import (
     get_project,
     get_asset_by_name,
     get_representations,
+    get_last_version_by_subset_name,
 )
+from openpype.pipeline.create import get_subset_name
 from openpype.settings import get_project_settings
 from openpype.lib import (
     filter_profiles,
@@ -538,30 +541,44 @@ def get_last_workfile_representation(
     project_name: str,
     asset_name: str,
     task_name: str,
+    asset_id=None,
+    asset_doc: dict = None,
+    fields: Iterable[str] = None,
 ) -> dict:
     """Get last published workfile representation.
 
     Args:
         project_name(str): Project name.
         asset_name(str): Asset/Shot name.
-        task_name(str): Task name.
+        task_name (str): Task name.
+        asset_id (Optional[Union[str, ObjectId]]): Asset id.
+            subset name. Defaults to None.
+        asset_doc (Optional[dict]): Asset doc. Defaults to None.
+        fields (Optional[Iterable[str]]): Fields that should be returned.
+            Defaults to None.
 
     Returns:
         dict: Last workfile representation.
     """
-    return max(
-        filter(
-            lambda r: r["context"].get("version") is not None,
-            list(
-                get_representations(
-                    project_name,
-                    context_filters={
-                        "asset": asset_name,
-                        "family": "workfile",
-                        "task": {"name": task_name},
-                    },
-                )
-            ),
+    if not asset_doc:
+        asset_doc = get_asset_by_name(project_name, asset_name)
+
+    last_version = get_last_version_by_subset_name(
+        project_name,
+        get_subset_name(
+            "workfile",
+            "",
+            task_name,
+            asset_doc,
+            project_name=project_name,
         ),
-        key=lambda r: r["context"]["version"],
+        asset_id=asset_id,
+        asset_name=asset_name,
+        fields=["_id"],
     )
+
+    return get_representations(
+        project_name,
+        version_ids=[last_version["_id"]],
+        fields=fields,
+    )[0]


### PR DESCRIPTION
## Changelog Description
Backporting changes made to the `get_last_workfile_representation` method as well as `copy last published workfile` hook in order to fix issues reported with the current implementation.

## Additional info
This isn't yet validated in its original PR on the develop branch, so there may be more changes coming, but in its current state, ongoing issues are fixed by these changes.

## Testing notes:
- Download a workfile with the `copy last published workfile` pre launch hook (fab_old technique)
- Open an asset that has no workfile and has never been published (Choochoo on prod_test for instance)