### PR TITLE
Feature/backport force download last wf

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -162,24 +162,36 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         extension = last_published_workfile_path.split(".")[-1]
 
-        # Use last local workfile version + 1
-        # or last published workfile version + 1
+        # Get last published workfile version
+        last_published_workfile_version = workfile_representation["context"][
+            "version"
+        ]
+
+        # Get last local workfile version
+        last_local_workfile_version = get_last_workfile_with_version(
+            get_workdir(
+                project_doc,
+                asset_doc,
+                task_name,
+                host_name,
+                anatomy=anatomy,
+                template_key=template_key,
+                project_settings=project_settings,
+            ),
+            anatomy.templates[template_key]["file"],
+            workfile_data,
+            [extension],
+        )[1]
+
+        # Use last published workfile version + 1
+        # or last local workfile version + 1 if it's higher
         workfile_data["version"] = (
-            get_last_workfile_with_version(
-                get_workdir(
-                    project_doc,
-                    asset_doc,
-                    task_name,
-                    host_name,
-                    anatomy=anatomy,
-                    template_key=template_key,
-                    project_settings=project_settings,
-                ),
-                anatomy.templates[template_key]["file"],
-                workfile_data,
-                [extension],
-            )[1]
-            or workfile_representation["context"]["version"]
+            last_local_workfile_version if (
+                last_local_workfile_version
+                and last_local_workfile_version
+                > last_published_workfile_version
+            )
+            else last_published_workfile_version
         ) + 1
         workfile_data["ext"] = extension
 

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -15,6 +15,8 @@ from openpype.pipeline.template_data import get_template_data
 from openpype.pipeline.workfile.path_resolving import (
     get_workfile_template_key,
     get_last_workfile_representation,
+    get_last_workfile_with_version,
+    get_workdir,
 )
 from openpype.settings.lib import get_project_settings
 
@@ -53,7 +55,9 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Check there is no workfile available
         last_workfile = self.data.get("last_workfile_path")
-        if os.path.exists(last_workfile):
+        if os.path.exists(last_workfile) and not self.data.get(
+            "force_download_last_workfile"
+        ):
             self.log.debug(
                 "Last workfile exists. Skipping {} process.".format(
                     self.__class__.__name__
@@ -157,7 +161,22 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         extension = last_published_workfile_path.split(".")[-1]
         workfile_data["version"] = (
-                workfile_representation["context"]["version"] + 1)
+            get_last_workfile_with_version(
+                get_workdir(
+                    project_doc,
+                    asset_doc,
+                    task_name,
+                    host_name,
+                    anatomy=anatomy,
+                    template_key=template_key,
+                    project_settings=project_settings,
+                ),
+                anatomy.templates[template_key]["file"],
+                workfile_data,
+                [extension],
+            )[1]
+            or workfile_representation["context"]["version"]
+        ) + 1
         workfile_data["ext"] = extension
 
         anatomy_result = anatomy.format(workfile_data)

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -185,15 +185,14 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Use last published workfile version + 1
         # or last local workfile version + 1 if it's higher
-        workfile_data["version"] = (
-            last_local_workfile_version if (
-                last_local_workfile_version
-                and last_local_workfile_version
-                > last_published_workfile_version
+        workfile_data["version"] = max(
+            (
+                last_local_workfile_version or 0,
+                last_published_workfile_version or 0,
             )
-            else last_published_workfile_version
         ) + 1
         workfile_data["ext"] = extension
+        workfile_data["comment"] = "downloaded"
 
         anatomy_result = anatomy.format(workfile_data)
         local_workfile_path = anatomy_result[template_key]["path"]

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -53,7 +53,8 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             self.log.debug("Sync server module is not enabled or available")
             return
 
-        # Check there is no workfile available
+        # Skip if there are local workfiles
+        # and force download last workfile is active
         last_workfile = self.data.get("last_workfile_path")
         if os.path.exists(last_workfile) and not self.data.get(
             "force_download_last_workfile"
@@ -160,6 +161,9 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         )
 
         extension = last_published_workfile_path.split(".")[-1]
+
+        # Use last local workfile version + 1
+        # or last published workfile version + 1
         workfile_data["version"] = (
             get_last_workfile_with_version(
                 get_workdir(

--- a/openpype/tools/launcher/constants.py
+++ b/openpype/tools/launcher/constants.py
@@ -9,6 +9,7 @@ ANIMATION_START_ROLE = QtCore.Qt.UserRole + 4
 ANIMATION_STATE_ROLE = QtCore.Qt.UserRole + 5
 FORCE_NOT_OPEN_WORKFILE_ROLE = QtCore.Qt.UserRole + 6
 ACTION_TOOLTIP_ROLE = QtCore.Qt.UserRole + 7
+FORCE_DOWNLOAD_LAST_WORKFILE_ROLE = QtCore.Qt.UserRole + 8
 
 # Animation length in seconds
 ANIMATION_LEN = 7

--- a/openpype/tools/launcher/delegates.py
+++ b/openpype/tools/launcher/delegates.py
@@ -3,7 +3,8 @@ from qtpy import QtCore, QtWidgets, QtGui
 from .constants import (
     ANIMATION_START_ROLE,
     ANIMATION_STATE_ROLE,
-    FORCE_NOT_OPEN_WORKFILE_ROLE
+    FORCE_NOT_OPEN_WORKFILE_ROLE,
+    FORCE_DOWNLOAD_LAST_WORKFILE_ROLE,
 )
 
 
@@ -71,11 +72,24 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
         super(ActionDelegate, self).paint(painter, option, index)
 
+        # Add skip opening last workfile marker
         if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
             rect = QtCore.QRectF(option.rect.x(), option.rect.height(),
                                  5, 5)
             painter.setPen(QtCore.Qt.transparent)
             painter.setBrush(QtGui.QColor(200, 0, 0))
+            painter.drawEllipse(rect)
+
+            painter.setBrush(self.extender_bg_brush)
+
+        # Add force download last workfile marker
+        if index.data(FORCE_DOWNLOAD_LAST_WORKFILE_ROLE):
+            rect = QtCore.QRectF(
+                option.rect.width(), option.rect.height(), 5, 5
+            )
+
+            painter.setPen(QtCore.Qt.transparent)
+            painter.setBrush(QtGui.QColor(0, 200, 0))
             painter.drawEllipse(rect)
 
             painter.setBrush(self.extender_bg_brush)

--- a/openpype/tools/launcher/delegates.py
+++ b/openpype/tools/launcher/delegates.py
@@ -75,8 +75,9 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
         # Add skip opening last workfile marker
         if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
-            rect = QtCore.QRectF(option.rect.x() + 5, option.rect.height() - 22.5,
-                                 5, 5)
+            rect = QtCore.QRectF(
+                option.rect.x() + 5, option.rect.height() - 22.5, 5, 5
+            )
             painter.setPen(QtCore.Qt.transparent)
             painter.setBrush(QtGui.QColor(200, 0, 0))
             painter.drawEllipse(rect)
@@ -92,7 +93,6 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
             painter.setPen(QtGui.QColor(70, 193, 191))
             painter.drawText(point, awesome["download"])
-
 
         is_group = False
         for group_role in self.group_roles:

--- a/openpype/tools/launcher/delegates.py
+++ b/openpype/tools/launcher/delegates.py
@@ -6,6 +6,7 @@ from .constants import (
     FORCE_NOT_OPEN_WORKFILE_ROLE,
     FORCE_DOWNLOAD_LAST_WORKFILE_ROLE,
 )
+from openpype.tools.pyblish_pype.awesome import tags as awesome
 
 
 class ActionDelegate(QtWidgets.QStyledItemDelegate):
@@ -74,7 +75,7 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
         # Add skip opening last workfile marker
         if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
-            rect = QtCore.QRectF(option.rect.x(), option.rect.height(),
+            rect = QtCore.QRectF(option.rect.x() + 5, option.rect.height() - 22.5,
                                  5, 5)
             painter.setPen(QtCore.Qt.transparent)
             painter.setBrush(QtGui.QColor(200, 0, 0))
@@ -84,15 +85,14 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
         # Add force download last workfile marker
         if index.data(FORCE_DOWNLOAD_LAST_WORKFILE_ROLE):
-            rect = QtCore.QRectF(
-                option.rect.width(), option.rect.height(), 5, 5
+            point = QtCore.QPointF(
+                option.rect.width() - 7.5,
+                option.rect.height() - 16,
             )
 
-            painter.setPen(QtCore.Qt.transparent)
-            painter.setBrush(QtGui.QColor(0, 200, 0))
-            painter.drawEllipse(rect)
+            painter.setPen(QtGui.QColor(70, 193, 191))
+            painter.drawText(point, awesome["download"])
 
-            painter.setBrush(self.extender_bg_brush)
 
         is_group = False
         for group_role in self.group_roles:

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -69,10 +69,13 @@ class ActionModel(QtGui.QStandardItemModel):
         path = appdirs.user_data_dir("openpype", "pypeclub")
         self.launcher_registry = JSONSettingRegistry("launcher", path)
 
+        # Ensure `force_not_open_workfile` is in the launcher registry
         try:
             _ = self.launcher_registry.get_item("force_not_open_workfile")
         except ValueError:
             self.launcher_registry.set_item("force_not_open_workfile", [])
+
+        # Ensure `force_download_last_workfile` is in the launcher registry
         try:
             _ = self.launcher_registry.get_item("force_download_last_workfile")
         except ValueError:
@@ -233,9 +236,12 @@ class ActionModel(QtGui.QStandardItemModel):
 
         self.beginResetModel()
 
+        # Get `force_not_open_workfile` setting from launcher registry
         stored_force_not_open_workfile = self.launcher_registry.get_item(
             "force_not_open_workfile"
         )
+
+        # Get `force_download_last_workfile` setting from launcher registry
         stored_force_download_last_workfile = self.launcher_registry.get_item(
             "force_download_last_workfile"
         )
@@ -245,15 +251,17 @@ class ActionModel(QtGui.QStandardItemModel):
                 item_id = str(uuid.uuid4())
                 item.setData(item_id, ACTION_ID_ROLE)
 
-                if self.is_force_not_open_workfile(
+                if self.is_context_menu_checkbox_ticked(
                     item, stored_force_not_open_workfile
                 ):
+                    # Set skip opening last workfile checkbox
                     self.change_action_item(
                         item, True, FORCE_NOT_OPEN_WORKFILE_ROLE
                     )
-                elif self.is_force_not_open_workfile(
+                elif self.is_context_menu_checkbox_ticked(
                     item, stored_force_download_last_workfile
                 ):
+                    # Set force download last workfile checkbox
                     self.change_action_item(
                         item, True, FORCE_DOWNLOAD_LAST_WORKFILE_ROLE
                     )
@@ -375,16 +383,18 @@ class ActionModel(QtGui.QStandardItemModel):
 
         return ApplicationAction in action.__bases__
 
-    def is_force_not_open_workfile(self, item, stored):
-        """Checks if application for task is marked to not open workfile
-
-        There might be specific tasks where is unwanted to open workfile right
-        always (broken file, low performance). This allows artist to mark to
-        skip opening for combination (project, asset, task_name, app)
+    def is_context_menu_checkbox_ticked(
+        self, item: QtGui.QStandardItem, stored: List[Dict]
+    ) -> bool:
+        """Check if the specified context menu checkbox is ticked for
+        the selected application, asset and task.
 
         Args:
-            item (QStandardItem)
-            stored (list) of dict
+            item (QStandardItem): Context menu item.
+            stored (List[Dict]): Stored settings in action registry.
+
+        Returns:
+            bool: True if the context menu checkbox is ticked.
         """
 
         actions = item.data(ACTION_ROLE)

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import collections
 import time
+from typing import List, Dict
 
 import appdirs
 from qtpy import QtCore, QtGui
@@ -71,6 +72,10 @@ class ActionModel(QtGui.QStandardItemModel):
             _ = self.launcher_registry.get_item("force_not_open_workfile")
         except ValueError:
             self.launcher_registry.set_item("force_not_open_workfile", [])
+        try:
+            _ = self.launcher_registry.get_item("force_download_last_workfile")
+        except ValueError:
+            self.launcher_registry.set_item("force_download_last_workfile", [])
 
     def discover(self):
         """Set up Actions cache. Run this for each new project."""
@@ -227,15 +232,26 @@ class ActionModel(QtGui.QStandardItemModel):
 
         self.beginResetModel()
 
-        stored = self.launcher_registry.get_item("force_not_open_workfile")
+        stored_force_not_open_workfile = self.launcher_registry.get_item(
+            "force_not_open_workfile"
+        )
+        stored_force_download_last_workfile = self.launcher_registry.get_item(
+            "force_download_last_workfile"
+        )
         items = []
         for order in sorted(items_by_order.keys()):
             for item in items_by_order[order]:
                 item_id = str(uuid.uuid4())
                 item.setData(item_id, ACTION_ID_ROLE)
 
-                if self.is_force_not_open_workfile(item,
-                                                   stored):
+                if (
+                    self.is_force_not_open_workfile(
+                        item, stored_force_not_open_workfile
+                    )
+                    or self.is_force_not_open_workfile(
+                        item, stored_force_download_last_workfile
+                    )
+                ):
                     self.change_action_item(item, True)
 
                 self.items_by_id[item_id] = item

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -354,8 +354,12 @@ class ActionModel(QtGui.QStandardItemModel):
         """
         tooltip = item.data(QtCore.Qt.ToolTipRole)
         if checked:
-            # TODO: Force download last workfile tooltip.
-            tooltip += " (Not opening last workfile)"
+            tooltip += (
+                " (Not opening last workfile)" if (
+                    checkbox_role == FORCE_NOT_OPEN_WORKFILE_ROLE
+                )
+                else " (Force download last workfile)"
+            )
 
         item.setData(tooltip, QtCore.Qt.ToolTipRole)
         item.setData(checked, checkbox_role)

--- a/openpype/tools/launcher/models.py
+++ b/openpype/tools/launcher/models.py
@@ -276,10 +276,13 @@ class ActionModel(QtGui.QStandardItemModel):
             key=lambda action: (action.order, action.name)
         )
 
-    def update_force_not_open_workfile_settings(self, is_checked, action_id):
+    def update_context_menu_settings(
+        self, item_name: str, is_checked: bool, action_id: str
+    ):
         """Store/remove config for forcing to skip opening last workfile.
 
         Args:
+            item_name (str): Context menu item name.
             is_checked (bool): True to add, False to remove
             action_id (str)
         """
@@ -296,7 +299,7 @@ class ActionModel(QtGui.QStandardItemModel):
             for action in actions
         ]
 
-        stored = self.launcher_registry.get_item("force_not_open_workfile")
+        stored = self.launcher_registry.get_item(item_name)
         for actual_data in action_actions_data:
             if is_checked:
                 stored.append(actual_data)
@@ -307,7 +310,7 @@ class ActionModel(QtGui.QStandardItemModel):
                         final_values.append(config)
                 stored = final_values
 
-        self.launcher_registry.set_item("force_not_open_workfile", stored)
+        self.launcher_registry.set_item(item_name, stored)
         self.launcher_registry._get_item.cache_clear()
         self.change_action_item(action_item, is_checked)
 

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -27,7 +27,8 @@ from .constants import (
     ANIMATION_START_ROLE,
     ANIMATION_STATE_ROLE,
     ANIMATION_LEN,
-    FORCE_NOT_OPEN_WORKFILE_ROLE
+    FORCE_NOT_OPEN_WORKFILE_ROLE,
+    FORCE_DOWNLOAD_LAST_WORKFILE_ROLE,
 )
 
 
@@ -284,11 +285,34 @@ class ActionBar(QtWidgets.QWidget):
 
         action_id = index.data(ACTION_ID_ROLE)
         checkbox.stateChanged.connect(
-            lambda: self.on_checkbox_changed(checkbox.isChecked(),
-                                             action_id))
+            lambda: self.on_checkbox_changed(
+                "force_not_open_workfile",
+                checkbox.isChecked(),
+                action_id,
+            )
+        )
         action = QtWidgets.QWidgetAction(menu)
         action.setDefaultWidget(checkbox)
 
+        menu.addAction(action)
+
+        force_download_checkbox = QtWidgets.QCheckBox(
+            "Force download last workfile.", menu
+        )
+
+        if index.data(FORCE_DOWNLOAD_LAST_WORKFILE_ROLE):
+            force_download_checkbox.setChecked(True)
+
+        force_download_checkbox.stateChanged.connect(
+            lambda: self.on_checkbox_changed(
+                "force_download_last_workfile",
+                force_download_checkbox.isChecked(),
+                action_id,
+            )
+        )
+
+        action = QtWidgets.QWidgetAction(menu)
+        action.setDefaultWidget(force_download_checkbox)
         menu.addAction(action)
 
         self._context_menu = menu
@@ -299,9 +323,10 @@ class ActionBar(QtWidgets.QWidget):
             self._discover_on_menu = False
             self.discover_actions()
 
-    def on_checkbox_changed(self, is_checked, action_id):
-        self.model.update_force_not_open_workfile_settings(is_checked,
-                                                           action_id)
+    def on_checkbox_changed(self, item_name, is_checked, action_id):
+        self.model.update_context_menu_settings(
+            item_name, is_checked, action_id
+        )
         self.view.update()
         if self._context_menu is not None:
             self._context_menu.close()
@@ -313,6 +338,9 @@ class ActionBar(QtWidgets.QWidget):
         is_group = index.data(GROUP_ROLE)
         is_variant_group = index.data(VARIANT_GROUP_ROLE)
         force_not_open_workfile = index.data(FORCE_NOT_OPEN_WORKFILE_ROLE)
+        force_download_last_workfile = index.data(
+            FORCE_DOWNLOAD_LAST_WORKFILE_ROLE
+        )
         if not is_group and not is_variant_group:
             action = index.data(ACTION_ROLE)
             # Change data of application action

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -278,6 +278,8 @@ class ActionBar(QtWidgets.QWidget):
             return
 
         menu = QtWidgets.QMenu(self.view)
+
+        # Create skip opening last workfile checkbox
         force_not_open_checkbox = QtWidgets.QCheckBox(
             "Skip opening last workfile.", menu
         )
@@ -298,6 +300,7 @@ class ActionBar(QtWidgets.QWidget):
 
         menu.addAction(action)
 
+        # Create force download last workfile checkbox
         force_download_checkbox = QtWidgets.QCheckBox(
             "Force download last workfile.", menu
         )
@@ -436,6 +439,7 @@ class ActionBar(QtWidgets.QWidget):
 
         action = actions_mapping[result]
         if issubclass(action, ApplicationAction):
+            # Set skip opening last workfile status in action data
             if force_not_open_workfile:
                 action.data["start_last_workfile"] = False
             else:

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -278,21 +278,23 @@ class ActionBar(QtWidgets.QWidget):
             return
 
         menu = QtWidgets.QMenu(self.view)
-        checkbox = QtWidgets.QCheckBox("Skip opening last workfile.",
-                                       menu)
+        force_not_open_checkbox = QtWidgets.QCheckBox(
+            "Skip opening last workfile.", menu
+        )
         if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
-            checkbox.setChecked(True)
+            force_not_open_checkbox.setChecked(True)
 
         action_id = index.data(ACTION_ID_ROLE)
-        checkbox.stateChanged.connect(
+        force_not_open_checkbox.stateChanged.connect(
             lambda: self.on_checkbox_changed(
                 "force_not_open_workfile",
-                checkbox.isChecked(),
+                force_not_open_checkbox.isChecked(),
                 action_id,
+                FORCE_NOT_OPEN_WORKFILE_ROLE,
             )
         )
         action = QtWidgets.QWidgetAction(menu)
-        action.setDefaultWidget(checkbox)
+        action.setDefaultWidget(force_not_open_checkbox)
 
         menu.addAction(action)
 
@@ -308,6 +310,7 @@ class ActionBar(QtWidgets.QWidget):
                 "force_download_last_workfile",
                 force_download_checkbox.isChecked(),
                 action_id,
+                FORCE_DOWNLOAD_LAST_WORKFILE_ROLE,
             )
         )
 
@@ -323,9 +326,23 @@ class ActionBar(QtWidgets.QWidget):
             self._discover_on_menu = False
             self.discover_actions()
 
-    def on_checkbox_changed(self, item_name, is_checked, action_id):
+    def on_checkbox_changed(
+        self,
+        item_name: str,
+        is_checked: bool,
+        action_id: str,
+        role: QtCore.Qt.UserRole,
+    ):
+        """Event triggered when context menu checkbox is ticked or unticked.
+
+        Args:
+            item_name (str): Checkbox item name.
+            is_checked (bool): True if checkbox is ticked on.
+            action_id (str): Launcher action identifier.
+            role (QtCore.Qt.UserRole): Checkbox Qt user role.
+        """
         self.model.update_context_menu_settings(
-            item_name, is_checked, action_id
+            item_name, is_checked, action_id, role
         )
         self.view.update()
         if self._context_menu is not None:

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -441,10 +441,10 @@ class ActionBar(QtWidgets.QWidget):
             else:
                 action.data.pop("start_last_workfile", None)
 
-            if force_download_last_workfile:
-                action.data["force_download_last_workfile"] = True
-            else:
-                action.data.pop("force_download_last_workfile", None)
+            # Set force download last workfile status in action data
+            action.data["force_download_last_workfile"] = (
+                force_download_last_workfile
+            )
 
         self._start_animation(index)
         self.action_clicked.emit(action)

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -441,6 +441,11 @@ class ActionBar(QtWidgets.QWidget):
             else:
                 action.data.pop("start_last_workfile", None)
 
+            if force_download_last_workfile:
+                action.data["force_download_last_workfile"] = True
+            else:
+                action.data.pop("force_download_last_workfile", None)
+
         self._start_animation(index)
         self.action_clicked.emit(action)
 

--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -369,6 +369,12 @@ class ActionBar(QtWidgets.QWidget):
                     action.data["start_last_workfile"] = False
                 else:
                     action.data.pop("start_last_workfile", None)
+
+                # Set force download last workfile status in action data
+                action.data["force_download_last_workfile"] = (
+                    force_download_last_workfile
+                )
+
             self._start_animation(index)
             self.action_clicked.emit(action)
             return


### PR DESCRIPTION
## Changelog Description
Backport of the `Force download last workfile feature`. This feature allows gives users the ability to download the last workfile BEFORE host app is launched, even if they already have local workfiles for the chosen project, asset and task.

In the launcher, when the user has chosen their project, asset and task, they can right click on the host app icon, and click on the "Force download last workfile" checkbox to trigger this feature. Then a small download icon will appear on the host app icon, as well as a mention that this feature is active in the tooltip.

Workfiles downloaded from this hook also have `downloaded` as their subversion.

## Additional info
Upcoming feature: Workfiles artist note will mention that a workfile was downloaded, and from which published version.

## Testing notes:
- Open the launcher and choose an asset and task for which you already have a downloaded workfile.
- Right click on the host app icon and select "Force download last workfile".
- Launch the host app.
- Last published workfile should be downloaded, no local workfile should be overwritten, and its version should be last published workfile + 1 or last local workfile + 1 (Whichever is greater).