### PR TITLE
Bugfix: Workfile last version not found

### DIFF
--- a/openpype/pipeline/workfile/path_resolving.py
+++ b/openpype/pipeline/workfile/path_resolving.py
@@ -577,6 +577,9 @@ def get_last_workfile_representation(
         fields=["_id"],
     )
 
+    if not last_version:
+        return
+
     return get_representations(
         project_name,
         version_ids=[last_version["_id"]],


### PR DESCRIPTION
## Changelog Description
Fixing error when no workfile representation exists, which makes last version None and causes an error in the `get_last_workfile_representation method`

## Testing notes:
- Launch `e132_sh047` in Layout task.
- It should open an empty workfile.