### PR TITLE
Enhancement: UDIM resources handling

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -446,21 +446,28 @@ def make_paths_absolute(source_filepath: Path = None):
 
         for d in relative_datablocks:
             try:
-                # Check if datablock is a resource file
-                for file in workfile_repre.get("files"):
-                    if Path(file.get("path", "")).name == Path(
-                        d.filepath
-                    ).name:
-                        # Make resource datablock path absolute,
-                        # starting from workdir
-                        d.filepath = str(
-                            Path(
-                                bpy.path.abspath(
-                                    d.filepath,
-                                )
-                            ).resolve()
+                # Check is datablock is a resource file or an UDIM
+                if (
+                    isinstance(d, bpy.types.Image)
+                    and d.source == "TILED"
+                    and not d.packed_file
+                    or any(
+                        (
+                            Path(file.get("path", "")).name
+                            == Path(d.filepath).name
+                            for file in workfile_repre.get("files")
                         )
-                        break
+                    )
+                ):
+                    # Make resource datablock path absolute,
+                    # starting from workdir
+                    d.filepath = str(
+                        Path(
+                            bpy.path.abspath(
+                                d.filepath,
+                            )
+                        ).resolve()
+                    )
                 else:
                     # Make datablock path absolute, starting from source path
                     d.filepath = str(

--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -446,18 +446,15 @@ def make_paths_absolute(source_filepath: Path = None):
 
         for d in relative_datablocks:
             try:
-                # Check is datablock is a resource file or an UDIM
+                # Check if datablock is a resource file or an UDIM
                 if (
                     isinstance(d, bpy.types.Image)
                     and d.source == "TILED"
                     and not d.packed_file
-                    or any(
-                        (
-                            Path(file.get("path", "")).name
-                            == Path(d.filepath).name
-                            for file in workfile_repre.get("files")
-                        )
-                    )
+                    or Path(d.filepath).name in {
+                        Path(file.get("path", "")).name
+                        for file in workfile_repre.get("files")
+                    }
                 ):
                     # Make resource datablock path absolute,
                     # starting from workdir

--- a/openpype/hosts/blender/plugins/publish/extract_blend.py
+++ b/openpype/hosts/blender/plugins/publish/extract_blend.py
@@ -189,8 +189,7 @@ class ExtractBlend(publish.Extractor):
     def _process_resources(
         self, instance: dict, images: set
     ) -> Tuple[List[Tuple[str, str]], dict, Set[Tuple[bpy.types.Image, Path]]]:
-        """Extract resources to transfer, copy them to the resource
-        directory and remap them.
+        """Extract, copy to resource directory and remap resources.
 
         UDIMs are handled as a single object that points to multiple files in
         the same directory. Only this object needs to be remapped, then blender


### PR DESCRIPTION
## Changelog Description
Allowing Blender UDIMs to be piped using the resources system, just like other images.

## Testing notes
- Import UDIMs into a workfile.
- Publish workfile.
- Use the `_old` technique to download the workfile you published long with its resources.
- All UDIMs should be in the resources directory.
- All UDIMS should be mapped to the local `resources` directory (work site not main site).