### PR TITLE
Bugfix: Switch asset duplicates nodegroups.

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -361,9 +361,10 @@ def transfer_stack(
         target_stack_datablock = target_col.get(stack_datablock.name)
         if not target_stack_datablock:
             if stack_name == "modifiers":
-                target_stack_datablock = target_col.new(
-                    stack_datablock.name, stack_datablock.type
-                )
+                if not stack_datablock.is_override_data:
+                    target_stack_datablock = target_col.new(
+                        stack_datablock.name, stack_datablock.type
+                    )
             else:
                 target_stack_datablock = target_col.new(stack_datablock.type)
 


### PR DESCRIPTION
## Changelog Description
Fixing unwanted behavior when switching asset with nodegroup modifiers:
- Nodegroups can be duplicated if they changed too much between both versions.
- Nodegroups that have been deleted in the target versions will be kept while they shouldn't.
- Nodegroups added locally are not reapplied after switching asset.

## Testing notes:
- Open `e138_sh037` Animation (Must be version `007`).
- Update Willy.
- His geoswitcher shouldn't be duplicated and his eyes should not bug.
- Open `e111_sh038` (layout).
- Switch SnowllyBally to versionned.
- It should keep its child of constrained.