### PR TITLE
Fix: Transfer action

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -338,6 +338,24 @@ def assign_loader_to_datablocks(
     return containers_loaders
 
 
+def transfer_action(old_datablock: bpy.types.ID, new_datablock: bpy.types.ID):
+    """Transfer action from a datablock to another one.
+
+    Args:
+        old_datablock (bpy.types.ID): Datablock to get action from.
+        new_datablock (bpy.types.ID): Datablock to create action to.
+    """
+    if (
+        hasattr(old_datablock, "animation_data")
+        and old_datablock.animation_data
+    ):
+        if not new_datablock.animation_data:
+            new_datablock.animation_data_create()
+        new_datablock.animation_data.action = (
+            old_datablock.animation_data.action
+        )
+
+
 def transfer_stack(
     source_datablock: bpy.types.ID,
     stack_name: str,


### PR DESCRIPTION
## Changelog Description
Generalize `object.data` override to allow an universal action transfer (even invisible ones).

## Testing notes:
1. Open `e109_sh020` layout
2. You may need to run `[o.pop('avalon') for o in C.scene.collection.all_objects if o.get('avalon')]`
3. Switch setdress to versioned, light animation is kept
