### PR TITLE
Restore: Remove frame end offset

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -135,7 +135,7 @@ def set_start_end_frames():
     scene.render.fps = round(fps)
     scene.render.fps_base = scene.render.fps / fps
     scene.frame_start = data.get("frameStart", scene.frame_start)
-    scene.frame_end = data.get("frameEnd", scene.frame_end) + 1
+    scene.frame_end = data.get("frameEnd", scene.frame_end)
     scene.render.resolution_x = data.get(
         "resolutionWidth", scene.render.resolution_x
     )


### PR DESCRIPTION
In fact, I've been confused by @BlueLag original report, there was actually no issue, or it has been badly documented... Blender is actually frame end inclusive, and this is why the sequencer doesn't look the same as the dopesheet. (see https://projects.blender.org/blender/blender/issues/99626)

Removing the frame end offset introduced with https://github.com/kaamaurice/OpenPype/pull/154