### PR TITLE
Fix: Synced representations before paths remapping

### DIFF
--- a/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
+++ b/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
@@ -86,8 +86,6 @@ class UnpauseSyncServer(pyblish.api.ContextPlugin):
     order = StartTimer.order
 
     def process(self, context):
-        project_name = context.data["projectEntity"]["name"]
-
         # Wait for all started futures to finish
         subprocess_errors = False
         for future in as_completed(
@@ -114,7 +112,9 @@ class UnpauseSyncServer(pyblish.api.ContextPlugin):
 
         # Unpause sync server
         sync_server_module = context.data["openPypeModules"]["sync_server"]
-        sync_server_module.unpause_project(project_name)
+        sync_server_module.unpause_project(
+            context.data["projectEntity"]["name"]
+        )
 
         if subprocess_errors:
             raise RuntimeError(

--- a/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
+++ b/openpype/hosts/blender/plugins/publish/unpause_sync_server.py
@@ -87,8 +87,6 @@ class UnpauseSyncServer(pyblish.api.ContextPlugin):
 
     def process(self, context):
         project_name = context.data["projectEntity"]["name"]
-        sync_server_module = context.data["openPypeModules"]["sync_server"]
-        sync_server_module.unpause_project(project_name)
 
         # Wait for all started futures to finish
         subprocess_errors = False
@@ -114,7 +112,10 @@ class UnpauseSyncServer(pyblish.api.ContextPlugin):
             else:
                 self.log.info(result)
 
-        # Stop if errors
+        # Unpause sync server
+        sync_server_module = context.data["openPypeModules"]["sync_server"]
+        sync_server_module.unpause_project(project_name)
+
         if subprocess_errors:
             raise RuntimeError(
                 "Errors occured during subprocesses. See above."


### PR DESCRIPTION
It may occur representations are synced before the remap is done, that is because the server is unpaused before all subprocessed have complete, if the loop runs during this short period of time, it'll be synced with wrong paths.

## Testing notes:
1. Hard to test in an accurate way.
