### PR TITLE
Fix: replace_datablocks adds numbers to name

### DIFF
--- a/openpype/hosts/blender/api/utils.py
+++ b/openpype/hosts/blender/api/utils.py
@@ -764,6 +764,9 @@ def replace_datablocks(
         ):
             old_datablock.user_remap(new_datablock)
 
+            # Transfer name
+            new_datablock.name = new_datablock["source_name"]
+
             # Remove remapped datablock
             datablocks_to_remap.remove(new_datablock)
 


### PR DESCRIPTION
Because loading datablocks with same name may incitate blender to add `.###` numbers to the end of object names, which could be confusing, we must ensure name by restoring source name.

## Testing notes:
1. Build `e114_sh027` anim
