### PR TITLE
Fix: Change get_task_by_name into get_task_by_entity

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -68,7 +68,7 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
                         "Task type {} not found in Kitsu!".format(task_name)
                     )
 
-                kitsu_task = gazu.task.get_task_by_name(
+                kitsu_task = gazu.task.get_task_by_entity(
                     entity, kitsu_task_type
                 )
 


### PR DESCRIPTION
## Changelog Description
Changing `gazu.task.get_task_by_name` into `gazu.task.get_task_by_entity` as it will eventually be deprecated. The new method name is just a proxy so it doesn't change anything for now. It will simply prevent a bug from appearing in the future.
