### PR TITLE
Fix: Cannot edit overrides of linked datablock

### DIFF
--- a/openpype/hosts/blender/api/plugin.py
+++ b/openpype/hosts/blender/api/plugin.py
@@ -771,13 +771,6 @@ class Loader(LoaderPlugin):
 
         replace_datablocks(old_datablocks, datablocks)
 
-        # Update override library operations from asset objects if available.
-        for obj in datablocks:
-            if isinstance(obj, bpy.types.Object) and getattr(
-                obj.override_library, "operations_update", None
-            ):
-                obj.override_library.operations_update()
-
         return container, datablocks
 
     @exec_process


### PR DESCRIPTION
Remove `operations_update` function that I don't really know what it was needed for and even if it is useful here. It was added by Kevin, and I don't notice any wrong behaviour by removing it. Please make sure it works well before validating! @BlueLag you're much aware about how a scene is supposed to behave.

## Testing notes:
1. Cherry-pick the commit on the last branch release
2. Build `E134_sh046` animation
