### PR TITLE
Feature: Skip Integrate Kitsu Note when comment already set

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -7,7 +7,7 @@ import re
 class IntegrateKitsuNote(pyblish.api.ContextPlugin):
     """Integrate Kitsu Note"""
 
-    order = pyblish.api.IntegratorOrder
+    order = pyblish.api.IntegratorOrder - 0.01
     label = "Kitsu Note and Status"
     families = ["render", "image", "online", "plate", "kitsu"]
 
@@ -50,6 +50,13 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
 
     def process(self, context):
         for instance in context:
+            # Skip if comment is already set
+            if instance.data.get("kitsu_comment"):
+                self.log.info(
+                    "Kitsu comment already set, skipping comment creation instance..."
+                )
+                continue
+
             # Check if instance is a review by checking its family
             # Allow a match to primary family or any of families
             families = set(

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -53,7 +53,8 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             # Skip if comment is already set
             if instance.data.get("kitsu_comment"):
                 self.log.info(
-                    "Kitsu comment already set, skipping comment creation instance..."
+                    "Kitsu comment already set, "
+                    "skipping comment creation for instance..."
                 )
                 continue
 


### PR DESCRIPTION
Allow to update a comment from a later process by reusing its id data. Useful with render farm, the comment is published directly and then the render comes when rendered.

## Testing notes:
Hard to test because the farm isn't set yet
