### PR TITLE
Add subset lock system

### DIFF
--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -154,6 +154,9 @@ def set_use_file_compression():
 def on_new():
     set_start_end_frames()
     set_use_file_compression()
+    bpy.types.WindowManager.subset_is_locked = bpy.props.BoolProperty(
+        name="Is subset locked",
+    )
 
     project = os.environ.get("AVALON_PROJECT")
     settings = get_project_settings(project)

--- a/openpype/hosts/blender/plugins/publish/validate_no_lock.py
+++ b/openpype/hosts/blender/plugins/publish/validate_no_lock.py
@@ -1,0 +1,40 @@
+import bpy
+import pyblish.api
+
+from openpype.hosts.blender.api.lock import (
+    get_lock_system_enabled,
+    subset_is_locked_and_lock_is_valid,
+)
+
+
+class ValidateFileNotLocked(pyblish.api.ContextPlugin):
+    """Subset must not be locked in database."""
+
+    order = pyblish.api.ValidatorOrder
+    hosts = ["blender"]
+    label = "Validate File Not Locked"
+
+    def process(self, context):
+        """ContextPlugin processing method.
+
+        Args:
+            context (pyblish.api.Context): Context with which to process
+        """
+        if not get_lock_system_enabled():
+            return
+
+        # Use stored attribute as it's the lock state when
+        # the scene was opened
+        if hasattr(context.window_manager, "subset_is_locked"):
+            lock = context.window_manager.subset_is_locked
+
+        # Fallback on the check function otherwise
+        # but if the file was unlocked between the opening and the publish,
+        # the publish will be allowed, which can lead to invalid data
+        else:
+            lock = subset_is_locked_and_lock_is_valid()
+
+        if lock:
+            raise RuntimeError(
+                "You can't publish a file that was locked by someone else!"
+            )

--- a/openpype/pipeline/__init__.py
+++ b/openpype/pipeline/__init__.py
@@ -94,6 +94,7 @@ from .context_tools import (
     get_current_project_name,
     get_current_asset_name,
     get_current_task_name,
+    get_workfile_subset,
 )
 install = install_host
 uninstall = uninstall_host
@@ -193,7 +194,8 @@ __all__ = (
     "get_current_project_name",
     "get_current_asset_name",
     "get_current_task_name",
-
+    "get_workfile_subset",
+    
     # Backwards compatible function names
     "install",
     "uninstall",

--- a/openpype/pipeline/context_tools.py
+++ b/openpype/pipeline/context_tools.py
@@ -2,10 +2,11 @@
 
 import os
 import json
-import types
 import logging
 import platform
+import types
 import uuid
+from typing import Optional
 
 import pyblish.api
 from pyblish.lib import MessageHandler
@@ -16,10 +17,12 @@ from openpype.client import (
     get_project,
     get_asset_by_id,
     get_asset_by_name,
+    get_subset_by_name,
     version_is_latest,
 )
 from openpype.lib.events import emit_event
 from openpype.modules import load_modules, ModulesManager
+from openpype.pipeline.create import get_subset_name
 from openpype.settings import get_project_settings
 
 from .publish.lib import filter_pyblish_plugins
@@ -37,7 +40,6 @@ from . import (
     deregister_loader_plugin_path,
     deregister_inventory_action_path,
 )
-
 
 _is_installed = False
 _process_id = None
@@ -408,6 +410,44 @@ def get_current_project_asset(asset_name=None, asset_id=None, fields=None):
         if not asset_name:
             return None
     return get_asset_by_name(project_name, asset_name, fields=fields)
+
+
+def get_workfile_subset(
+        project_name: str,
+        asset_name: str,
+        task_name: str
+) -> Optional[dict]:
+    """Helper function to get workfile subset from project, asset and task.
+
+    Args:
+        project_name (str): Project's name.
+        asset_name (str): Asset's name.
+        task_name (str): Task's name.
+
+    Returns:
+        Optional[dict]: Related subset if found else None.
+    """
+    if not project_name or not asset_name or not task_name:
+        return None
+
+    asset_doc = get_asset_by_name(
+            project_name, asset_name, fields={"_id"}
+    )
+
+    if not asset_doc:
+        return None
+
+    return get_subset_by_name(
+        project_name,
+        get_subset_name(
+            "workfile",
+            "",
+            task_name,
+            asset_doc,
+            project_name=project_name
+        ),
+        asset_doc["_id"]
+    )
 
 
 def is_representation_from_latest(representation):

--- a/openpype/pipeline/lock.py
+++ b/openpype/pipeline/lock.py
@@ -1,0 +1,177 @@
+"""Lock module to specify a subset is locked or not in the Db.
+
+Also stores lock date and site as last_opened data.
+"""
+
+from datetime import datetime, timedelta
+
+from openpype.lib import get_local_site_id
+from openpype.pipeline import (
+    get_current_project_name,
+    get_current_asset_name,
+    get_current_task_name,
+    get_workfile_subset,
+    AvalonMongoDB,
+)
+from openpype.settings import get_project_settings
+
+
+def lock_subset(subset: dict):
+    """Lock a subset in the db.
+
+    Args:
+        subset (dict): Subset to lock.
+    """
+    if subset is None:
+        raise Exception("Subset not found.")
+
+    update_item_in_db_from_id(
+        subset,
+        {
+            "$set": {
+                "data.last_opened.date": datetime.now(),
+                "data.last_opened.site": get_local_site_id(),
+                "data.last_opened.locked": True,
+            }
+        },
+    )
+
+
+def unlock_subset(subset: dict):
+    """Unlock a subset in the db.
+
+    Args:
+        subset (dict): Subset to unlock.
+    """
+    if subset is None:
+        raise Exception("Subset not found.")
+
+    update_item_in_db_from_id(
+        subset,
+        {"$set": {"data.last_opened.locked": False}},
+    )
+
+
+def subset_is_locked_and_lock_is_valid() -> bool:
+    """Check if current subset is locked and its lock is valid.
+
+    Returns:
+        bool: True if current subset is locked and the lock is still valid.
+    """
+    workfile_subset = get_workfile_subset(
+        get_current_project_name(),
+        get_current_asset_name(),
+        get_current_task_name(),
+    )
+    return (
+        workfile_subset
+        and subset_is_locked(workfile_subset)
+        and not locked_on_same_site(workfile_subset)
+        and subset_lock_is_valid(workfile_subset)
+    )
+
+
+def get_lock_settings() -> dict:
+    """Get lock settings.
+
+    Returns:
+        dict: Project's lock settings.
+    """
+    return get_project_settings(get_current_project_name())["global"]["tools"][
+        "loader"
+    ].get("LockFileInDb", {})
+
+
+def get_last_opened_data(subset: dict) -> dict:
+    """Get last opened data settings.
+    61
+
+        Args:
+            subset (dict): The subset to check.
+
+        Returns:
+            dict: Subset's last opened data.
+    """
+    return subset.get("data").get("last_opened")
+
+
+def get_flush_delta() -> float:
+    """Get lock flush delay.
+
+    Returns:
+        float: Flush delay (in hour(s)) from settings or 72.
+    """
+    return get_lock_settings().get("flush_delay", 72.0)
+
+
+def get_lock_system_enabled() -> bool:
+    """Get lock system is enabled on the project.
+
+    Returns:
+        bool: True if lock system is enabled in project's settings, else False.
+    """
+    return get_lock_settings().get("enabled", False)
+
+
+def subset_lock_is_valid(subset: dict) -> bool:
+    """Check subset lock is valid.
+
+    A subset lock is valid if it was created sooner than the lock flush delay.
+
+    Args:
+        subset (dict): The subset to check.
+
+    Returns:
+        bool: Subset was locked before than the flush delay, or not.
+    """
+    return subset.get("data").get("last_opened").get("date") > (
+        datetime.now() - timedelta(hours=get_flush_delta())
+    )
+
+
+def subset_is_locked(subset: dict) -> bool:
+    """Check subset is locked.
+
+    Args:
+        subset (dict): The subset to check.
+
+    Returns:
+        bool: True if the subset is locked in the database, else False.
+    """
+    return get_last_opened_data(subset).get("locked")
+
+
+def locked_on_same_site(subset: dict) -> bool:
+    """Check if the subset's lock site matches local site.
+
+    Args:
+        subset (dict): The subset to check.
+
+    Returns:
+        bool: True if the subset site matches local site.
+    """
+    return (
+        get_last_opened_data(subset).get("site", None) == get_local_site_id()
+    )
+
+
+def get_project_database() -> AvalonMongoDB:
+    """Get project's mongodb database.
+
+    Returns:
+        (AvalonMongoDB): Project's mongodb database.
+    """
+
+    db = AvalonMongoDB()
+    db.Session["AVALON_PROJECT"] = get_current_project_name()
+    return db
+
+
+def update_item_in_db_from_id(item: dict, values: dict):
+    """Get mongodb client and update provided item.
+
+    Args:
+        item (dict): Item to update. Must contain "_id" key.
+        values (dict): Values to update in the db for provided item.
+    """
+    get_project_database().update_one({"_id": item["_id"]}, values)

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -553,7 +553,11 @@
                     "is_include": true,
                     "filter_families": []
                 }
-            ]
+            ],
+            "LockFileInDb": {
+                "enabled": false,
+                "flush_delay": 72
+            }
         },
         "publish": {
             "template_name_profiles": [

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_global_tools.json
@@ -312,6 +312,29 @@
                             }
                         ]
                     }
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "LockFileInDb",
+                    "label": "Lock opened file in database",
+                    "checkbox_key": "enabled",
+                    "children": [
+
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "number",
+                            "key": "flush_delay",
+                            "label": "Flush delay (hours)",
+                            "decimal": 2,
+                            "minimum": 0,
+                            "maximum": 72
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
# Why this MR ?

This MR adds a system that adds lock subset in the db system.  
Also adds working behaviour in Blender.  

# Details

- Lock is removed when Blender is closed (using atexit lib)
- Lock is invalid when flush delay is passed (defined in project's settings, necessary if blender crashes and can't unlock)
- Lock is invalid when lock site is the same as user's local site

# Implementation

- All the functional code was added to a lock.py file in openpype/pipeline.
- An operator and a timer were added to the ops.py file in hosts/blender/api.

# How to test

- Open a blender file from OpenPype
- Once the scene is opened, close blender
- Go onto another computer (see bellow if you can't switch computer) and open the same blender file from OpenPype
- A popup should indicate you that the file is locked and that you can QUIT or PROCEED anyway

- If you can't switch computer:
  - As the site is the same between the lock one and yours, the only solution is to edit hosts/blender/api/lock.py locked_on_same_site() and compare with anything but get_local_site_id().
