### PR TITLE
Fix: Sync Representations query limit

### DIFF
--- a/openpype/modules/sync_server/sync_server_module.py
+++ b/openpype/modules/sync_server/sync_server_module.py
@@ -1674,6 +1674,7 @@ class SyncServerModule(OpenPypeModule, ITrayModule):
 
         aggr = [
             {"$match": match},
+            {"$limit": 5000},  # limit to 5000 representations at once
             {'$unwind': '$files'},
             {'$addFields': {
                 'order_remote': {


### PR DESCRIPTION
Big queries might block the server to process because they are too heavy (>100MB). Fixed by limiting the aggregation to a certain amount.

## Testing notes:

1. Stop Openpype of a site
2. Assign a lot of representations to the site
3. Restart OP on the site

You can use these files by changing the extension to `.py`:
- Remove all representations of site: [adhoc_site_sync_remove_site.txt](https://github.com/kaamaurice/OpenPype/files/14669753/adhoc_site_sync_remove_site.txt)

- Add all last and hero version to site (around 19000 repres): [sync_all_hero_and_last_versions_representations.txt](https://github.com/kaamaurice/OpenPype/files/14616350/sync_all_hero_and_last_versions_representations.txt)

NB: If run headless, make sure the site name env var `OPENPYPE_LOCAL_ID` is set correctly.


